### PR TITLE
Update callers of Exec to use a constructor in the API

### DIFF
--- a/api/server/exec.go
+++ b/api/server/exec.go
@@ -268,7 +268,6 @@ func (s *ExecService) Create(ctx context.Context, projectID string, params types
 		return nil, fmt.Errorf("failed to setup credentials: %w", err)
 	}
 
-	// Where a user assigns a session
 	node, err := s.assignNode(ctx, params.HardwareSpec, params.Region, keys)
 	if err != nil {
 		return nil, fmt.Errorf("failed to assign node: %w", err)
@@ -298,7 +297,6 @@ func (s *ExecService) Create(ctx context.Context, projectID string, params types
 		GitURL:   params.GitURL,
 	}
 
-	// Where we tell Coreweave to assign an Exec/Session
 	exec, err = s.init(ctx, projectID, node, execCfg, gitCfg, buildID, imageURI)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize exec: %w", err)

--- a/api/server/exec_init.go
+++ b/api/server/exec_init.go
@@ -167,18 +167,6 @@ func (s *ExecService) init(ctx context.Context, projectID string, node types.Nod
 		return nil, fmt.Errorf("failed to create exec in db: %w", err)
 	}
 
-	exec := &types.Exec{
-		ID:           execID,
-		Name:         dbp.Name,
-		SSHKey:       cfg.Keys[0],
-		Image:        cfg.Image,
-		Connection:   nil,
-		Status:       types.StatusInitializing,
-		CreatedAt:    &createdAt,
-		NodeTypeID:   node.TypeID,
-		Region:       node.Region,
-		Provider:     node.Provider,
-		PersistentFS: false,
-	}
+	exec := types.NewExec(execID, dbp.Name, cfg.Keys[0], cfg.Image, nil, types.StatusInitializing, &createdAt, node.TypeID, node.Region, node.Provider, node.Specs, false)
 	return exec, nil
 }

--- a/api/types/model.go
+++ b/api/types/model.go
@@ -119,10 +119,8 @@ type Exec struct {
 	ID           string          `json:"id"`
 	Name         string          `json:"name"`
 	SSHKey       SSHKey          `json:"sshKey"`
+	Specs        HardwareSpec    `json:"specs"`
 	Image        string          `json:"buildID,omitempty"`
-	Command      []string        `json:"command"`
-	CommitID     *string         `json:"commitID,omitempty"`
-	GitURL       *string         `json:"gitURL,omitempty"`
 	Connection   *ConnectionInfo `json:"connection,omitempty"`
 	Status       Status          `json:"status"`
 	CreatedAt    *time.Time      `json:"createdAt,omitempty"`
@@ -130,6 +128,10 @@ type Exec struct {
 	Region       string          `json:"region"`
 	Provider     Provider        `json:"provider"`
 	PersistentFS bool            `json:"persistentFS"`
+}
+
+func NewExec(ID string, name string, SSHKey SSHKey, image string, connection *ConnectionInfo, status Status, createdAt *time.Time, nodeTypeID string, region string, provider Provider, specs HardwareSpec, hasPersistentFS bool) *Exec {
+	return &Exec{ID: ID, Name: name, Specs: specs, Image: image, SSHKey: SSHKey, Connection: connection, Status: status, CreatedAt: createdAt, NodeTypeID: nodeTypeID, Region: region, Provider: provider, PersistentFS: hasPersistentFS}
 }
 
 type ExecConfig struct {


### PR DESCRIPTION
This PR adds HardwareSpec to the Exec struct as the first step to facilitate `unw-182` enabling us to use the HardwareSpec returned by the API when a new Exec is created to give us extra UI information. Using the exec as the source of truth should also keep HardwareSpec data current and catch use cases where you don't specify anything in your HardwareSpec (i.e. in the CLI) and end up with an `rtx_4000`, or cases where something weird happens where you end up with a different session to what you request.

A constructor is introduced to solve this issue alongside a few re-usable helper methods. The following fields have no usages so were also removed as they can't tie to any existing feature:

```
        Command      []string        `json:"command"`
	CommitID     *string         `json:"commitID,omitempty"`
	GitURL       *string         `json:"gitURL,omitempty"`
```
