### PR TITLE
Remove GPU type parsing from hardware spec

### DIFF
--- a/api/types/hardware.go
+++ b/api/types/hardware.go
@@ -19,16 +19,12 @@ type HardwareSpec struct {
 }
 
 const (
-	defaultMinCPU     = 1
-	defaultMinHDD     = 4
-	defaultMinGPUs    = 1
-	defaultGPURequest = "rtx_4000"
+	defaultMinCPU = 4
+	defaultMinHDD = 50
 )
 
 func SetSpecDefaultValues(spec HardwareSpec) HardwareSpec {
-	spec.GPU.Type = setDefaultGPU(spec.GPU.Type)
-
-	spec.GPU.Count.Min = setMinIfZero(spec.GPU.Count.Min, defaultMinGPUs)
+	spec.GPU.Count.Min = setDefaultMinGPUCount(spec.GPU)
 	spec.GPU.Count.Max = setMaxIfZeroOrBelowMin(spec.GPU.Count.Min, spec.GPU.Count.Max)
 
 	spec.CPU.Min = setMinIfZero(spec.CPU.Min, defaultMinCPU)
@@ -55,10 +51,16 @@ func setMaxIfZeroOrBelowMin(min, max int) int {
 	return max
 }
 
-func setDefaultGPU(val string) string {
-	if val == "" {
-		val = defaultGPURequest
+func setDefaultMinGPUCount(gpu GPU) int {
+	if gpu.Count.Min != 0 {
+		return gpu.Count.Min
 	}
 
-	return val
+	// User specified a GPU and didn't specify a min count. Use 1 as the default
+	if gpu.Type != "" {
+		return 1
+	}
+
+	// If no GPU type and no min count assume the user does not want a GPU
+	return 0
 }

--- a/api/types/hardware_test.go
+++ b/api/types/hardware_test.go
@@ -9,8 +9,6 @@ import (
 func TestSetDefaultValues(t *testing.T) {
 	g := Goblin(t)
 
-	const defaultGPU = "rtx_4000"
-
 	g.Describe("SetDefaultValues", func() {
 		g.It("should set default values for unset fields", func() {
 			g.Describe("when all fields are unset", func() {
@@ -18,11 +16,11 @@ func TestSetDefaultValues(t *testing.T) {
 				expectedSpec := HardwareSpec{
 					GPU: GPU{
 						Count: HardwareRequestRange{
-							Min: defaultMinGPUs,
-							Max: defaultMinGPUs,
+							Min: 0,
+							Max: 0,
 						},
 
-						Type: defaultGPU,
+						Type: "",
 					},
 					CPU: HardwareRequestRange{
 						Min: defaultMinCPU,
@@ -102,7 +100,7 @@ func TestSetDefaultValues(t *testing.T) {
 							Min: 2,
 							Max: 4,
 						},
-						Type: defaultGPU,
+						Type: "",
 					},
 					CPU: HardwareRequestRange{
 						Min: 4,


### PR DESCRIPTION
This PR removes gpu type parsing and relegates the responsibility to the individual providers. We now parse the hardware spec and setup the num-gpus based on whether the user asked for a specific gpu-type and min-gpus.

Individual providers are responsible for validating the gpu-type.