### PR TITLE
Add ServiceRouter to wrap and route exec service requests based on the provider

### DIFF
--- a/api/router/exec.go
+++ b/api/router/exec.go
@@ -35,7 +35,7 @@ func (e *ExecRouter) Routes() []Route {
 }
 
 func NewExecRouter(store execsrv.Store, lambdaLabsService, unweaveService *execsrv.ProviderService) *ExecRouter {
-	router := execsrv.NewServiceRouter(lambdaLabsService, unweaveService)
+	router := execsrv.NewServiceRouter(store, lambdaLabsService, unweaveService)
 	return &ExecRouter{
 		store:   store,
 		service: router,

--- a/api/router/exec.go
+++ b/api/router/exec.go
@@ -75,7 +75,7 @@ func (e *ExecRouter) ExecGetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	exec, err := e.store.Get(execID)
+	exec, err := e.service.Get(ctx, execID)
 	if err != nil {
 		render.Render(w, r.WithContext(ctx), types.ErrHTTPError(err, "Failed to get session"))
 		return
@@ -126,13 +126,7 @@ func (e *ExecRouter) ExecTerminateHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	_, err := e.service.Get(ctx, execID)
-	if err != nil {
-		render.Render(w, r.WithContext(ctx), types.ErrHTTPError(err, "Failed to get session"))
-		return
-	}
-
-	err = e.service.Terminate(ctx, execID)
+	err := e.service.Terminate(ctx, execID)
 	if err != nil {
 		render.Render(w, r.WithContext(ctx), types.ErrHTTPError(err, "Failed to terminate session"))
 		return

--- a/api/router/exec.go
+++ b/api/router/exec.go
@@ -42,19 +42,6 @@ func NewExecRouter(store execsrv.Store, lambdaLabsService, unweaveService *execs
 	}
 }
 
-//func (e *ExecRouter) service(provider types.Provider) *execsrv.service {
-//	switch provider {
-//	case types.LambdaLabsProvider:
-//		return e.llService
-//	case types.UnweaveProvider:
-//		return e.unweaveService
-//	default:
-//		// This is unreachable. Using panic for now until we have the conductor
-//		// implemented for AWS, GCP etc
-//		panic(fmt.Errorf("unknown provider: %s", provider))
-//	}
-//}
-
 func (e *ExecRouter) ExecCreateHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	log.Ctx(ctx).Info().Msgf("Executing ExecCreate request")

--- a/db/querier.go
+++ b/db/querier.go
@@ -16,6 +16,7 @@ type Querier interface {
 	ExecCreate(ctx context.Context, arg ExecCreateParams) error
 	ExecGet(ctx context.Context, idOrName string) (UnweaveExec, error)
 	ExecGetAllActive(ctx context.Context) ([]UnweaveExec, error)
+	ExecList(ctx context.Context, arg ExecListParams) ([]UnweaveExec, error)
 	ExecListActiveByProvider(ctx context.Context, provider string) ([]UnweaveExec, error)
 	ExecListByProvider(ctx context.Context, provider string) ([]UnweaveExec, error)
 	ExecSetError(ctx context.Context, arg ExecSetErrorParams) error

--- a/db/queries/exec.sql
+++ b/db/queries/exec.sql
@@ -22,6 +22,14 @@ select *
 from unweave.exec as e
 where e.provider = $1;
 
+-- name: ExecList :many
+select *
+from unweave.exec as e
+where (e.provider = coalesce(sqlc.narg('filter_provider'), e.provider))
+  and project_id = coalesce(sqlc.narg('filter_project_id'), project_id)
+  and ((@filter_active = true and (status = 'initializing' or status = 'running'))
+    or @filter_active = false);
+
 -- name: ExecListActiveByProvider :many
 select *
 from unweave.exec as e

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func main() {
 	lStatsInf := execsrv.NewPollingStatsInformerFunc(execStore, lDriver)
 	lHeartbeatInf := execsrv.NewPollingHeartbeatInformerFunc(lDriver, 10)
 
-	lls, err := execsrv.NewService(execStore, lDriver, lStateInf, lStatsInf, lHeartbeatInf)
+	lls, err := execsrv.NewProviderService(execStore, lDriver, lStateInf, lStatsInf, lHeartbeatInf)
 	if err != nil {
 		panic(err)
 	}

--- a/wip/services/exec/exec.go
+++ b/wip/services/exec/exec.go
@@ -16,8 +16,7 @@ type Store interface {
 	Create(project string, exec types.Exec) error
 	Get(id string) (types.Exec, error)
 	GetDriver(id string) (string, error)
-	List(project string) ([]types.Exec, error)
-	ListByProvider(provider types.Provider, filterActive bool) ([]types.Exec, error)
+	List(filterProject *string, filterProvider *types.Provider, filterActive bool) ([]types.Exec, error)
 	Delete(project, id string) error
 	Update(id string, exec types.Exec) error
 	UpdateStatus(id string, status types.Status) error

--- a/wip/services/exec/observers.go
+++ b/wip/services/exec/observers.go
@@ -7,10 +7,10 @@ import (
 
 type stateObserver struct {
 	exec types.Exec
-	srv  *Service
+	srv  *ProviderService
 }
 
-func NewStateObserverFunc(s *Service) StateObserverFunc {
+func NewStateObserverFunc(s *ProviderService) StateObserverFunc {
 	return func(exec types.Exec) StateObserver {
 		return &stateObserver{exec: exec, srv: s}
 	}

--- a/wip/services/exec/router.go
+++ b/wip/services/exec/router.go
@@ -1,0 +1,104 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/unweave/unweave/api/types"
+)
+
+type Service interface {
+	Create(ctx context.Context, projectID string, creator string, params types.ExecCreateParams) (types.Exec, error)
+	Get(ctx context.Context, execID string) (types.Exec, error)
+	List(ctx context.Context, projectID string) ([]types.Exec, error)
+	Terminate(ctx context.Context, execID string) error
+	Monitor(ctx context.Context, execID string) error
+}
+
+// ServiceRouter is a service that routes requests to the correct provider. In most cases
+// use should be using this service instead of provider specific services. This takes care
+// of routing requests based on the provider and aggregating responses from multiple
+// providers when needed.
+type ServiceRouter struct {
+	store          Store
+	llService      *ProviderService
+	unweaveService *ProviderService
+}
+
+func NewServiceRouter(lambdaLabsService, unweaveService *ProviderService) Service {
+	return &ServiceRouter{
+		llService:      lambdaLabsService,
+		unweaveService: unweaveService,
+	}
+}
+
+func (s *ServiceRouter) Create(ctx context.Context, project string, creator string, params types.ExecCreateParams) (types.Exec, error) {
+	switch params.Provider {
+	case types.LambdaLabsProvider:
+		return s.llService.Create(ctx, project, creator, params)
+	case types.UnweaveProvider:
+		return s.unweaveService.Create(ctx, project, creator, params)
+	default:
+		return types.Exec{}, fmt.Errorf("unknown provider: %s", params.Provider)
+	}
+}
+
+// Get returns a single session irrespective of the provider.
+func (s *ServiceRouter) Get(ctx context.Context, execID string) (types.Exec, error) {
+	// TODO: we probably want to clean this up somewhat and use a global store instead
+	exec, err := s.llService.Get(ctx, execID)
+	if err == nil {
+		return exec, nil
+	}
+	return s.unweaveService.Get(ctx, execID)
+}
+
+// List returns a list of sessions for a given project irrespective of the providers.
+func (s *ServiceRouter) List(ctx context.Context, projectID string) ([]types.Exec, error) {
+	llExecs, err := s.llService.List(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list LambdaLabs execs: %w", err)
+	}
+
+	uwExecs, err := s.unweaveService.List(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list Unweave execs: %w", err)
+	}
+
+	execs := append(llExecs, uwExecs...)
+	return execs, nil
+}
+
+// Terminate routes the exec termination request to the correct service based on the provider.
+func (s *ServiceRouter) Terminate(ctx context.Context, execID string) error {
+	exec, err := s.store.Get(execID)
+	if err != nil {
+		return fmt.Errorf("failed to get exec: %w", err)
+	}
+
+	switch exec.Provider {
+	case types.LambdaLabsProvider:
+		return s.llService.Terminate(ctx, execID)
+	case types.UnweaveProvider:
+		return s.unweaveService.Terminate(ctx, execID)
+	default:
+		return fmt.Errorf("unknown provider: %s", exec.Provider)
+	}
+}
+
+// Monitor routes the exec monitoring request to the correct service based on the provider.
+func (s *ServiceRouter) Monitor(ctx context.Context, execID string) error {
+	exec, err := s.store.Get(execID)
+	if err != nil {
+		return fmt.Errorf("failed to get exec: %w", err)
+	}
+
+	switch exec.Provider {
+	case types.LambdaLabsProvider:
+		return s.llService.Monitor(ctx, execID)
+	case types.UnweaveProvider:
+		return s.unweaveService.Monitor(ctx, execID)
+	default:
+		return fmt.Errorf("unknown provider: %s", exec.Provider)
+	}
+}

--- a/wip/services/exec/service.go
+++ b/wip/services/exec/service.go
@@ -17,6 +17,7 @@ var (
 type ProviderService struct {
 	store                 Store
 	driver                Driver
+	provider              types.Provider
 	stateInformerFunc     StateInformerFunc
 	statsInformerFunc     StatsInformerFunc
 	heartbeatInformerFunc HeartbeatInformerFunc
@@ -51,12 +52,13 @@ func NewProviderService(
 	s := &ProviderService{
 		store:                 store,
 		driver:                driver,
+		provider:              driver.Provider(),
 		stateInformerFunc:     stateInformerFunc,
 		statsInformerFunc:     statsInformerFunc,
 		heartbeatInformerFunc: heartbeatInformerFunc,
 	}
 
-	execs, err := store.ListByProvider(driver.Provider(), true)
+	execs, err := store.List(nil, &s.provider, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init StateInformer, failed list all execs: %w", err)
 	}
@@ -152,7 +154,7 @@ func (s *ProviderService) Get(ctx context.Context, id string) (types.Exec, error
 }
 
 func (s *ProviderService) List(ctx context.Context, project string) ([]types.Exec, error) {
-	execs, err := s.store.List(project)
+	execs, err := s.store.List(&project, &s.provider, false)
 	if err != nil {
 		return nil, err
 	}

--- a/wip/services/exec/service.go
+++ b/wip/services/exec/service.go
@@ -14,7 +14,7 @@ var (
 	DefaultImageURI = "ubuntu:latest"
 )
 
-type Service struct {
+type ProviderService struct {
 	store                 Store
 	driver                Driver
 	stateInformerFunc     StateInformerFunc
@@ -26,29 +26,29 @@ type Service struct {
 	heartbeatObserversFuncs []HeartbeatObserverFunc
 }
 
-func WithStateObserver(s *Service, f StateObserverFunc) *Service {
+func WithStateObserver(s *ProviderService, f StateObserverFunc) *ProviderService {
 	s.stateObserversFuncs = append(s.stateObserversFuncs, f)
 	return s
 }
 
-func WithStatsObserver(s *Service, f StatsObserverFunc) *Service {
+func WithStatsObserver(s *ProviderService, f StatsObserverFunc) *ProviderService {
 	s.statsObserversFuncs = append(s.statsObserversFuncs, f)
 	return s
 }
 
-func WithHeartbeatObserver(s *Service, f HeartbeatObserverFunc) *Service {
+func WithHeartbeatObserver(s *ProviderService, f HeartbeatObserverFunc) *ProviderService {
 	s.heartbeatObserversFuncs = append(s.heartbeatObserversFuncs, f)
 	return s
 }
 
-func NewService(
+func NewProviderService(
 	store Store,
 	driver Driver,
 	stateInformerFunc StateInformerFunc,
 	statsInformerFunc StatsInformerFunc,
 	heartbeatInformerFunc HeartbeatInformerFunc,
-) (*Service, error) {
-	s := &Service{
+) (*ProviderService, error) {
+	s := &ProviderService{
 		store:                 store,
 		driver:                driver,
 		stateInformerFunc:     stateInformerFunc,
@@ -85,7 +85,7 @@ func NewService(
 	return s, nil
 }
 
-func (s *Service) Create(ctx context.Context, project string, creator string, params types.ExecCreateParams) (types.Exec, error) {
+func (s *ProviderService) Create(ctx context.Context, project string, creator string, params types.ExecCreateParams) (types.Exec, error) {
 	image := DefaultImageURI
 	if params.Image != nil && *params.Image != "" {
 		image = *params.Image
@@ -143,7 +143,7 @@ func (s *Service) Create(ctx context.Context, project string, creator string, pa
 	return exec, nil
 }
 
-func (s *Service) Get(ctx context.Context, id string) (types.Exec, error) {
+func (s *ProviderService) Get(ctx context.Context, id string) (types.Exec, error) {
 	exec, err := s.store.Get(id)
 	if err != nil {
 		return types.Exec{}, err
@@ -151,7 +151,7 @@ func (s *Service) Get(ctx context.Context, id string) (types.Exec, error) {
 	return exec, err
 }
 
-func (s *Service) List(ctx context.Context, project string) ([]types.Exec, error) {
+func (s *ProviderService) List(ctx context.Context, project string) ([]types.Exec, error) {
 	execs, err := s.store.List(project)
 	if err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func (s *Service) List(ctx context.Context, project string) ([]types.Exec, error
 	return execs, nil
 }
 
-func (s *Service) Terminate(ctx context.Context, id string) error {
+func (s *ProviderService) Terminate(ctx context.Context, id string) error {
 	exec, err := s.store.Get(id)
 	if err != nil {
 		if err == ErrNotFound {
@@ -191,7 +191,7 @@ func (s *Service) Terminate(ctx context.Context, id string) error {
 
 // Monitor starts monitoring an exec by registering observers to the stats and heartbeat
 // informers.
-func (s *Service) Monitor(ctx context.Context, execID string) error {
+func (s *ProviderService) Monitor(ctx context.Context, execID string) error {
 	exec, err := s.store.Get(execID)
 	if err != nil {
 		return fmt.Errorf("failed to get exec from store: %w", err)


### PR DESCRIPTION
This add a `ServicerRouter` implementation of the `Service` interface the routes exec requests to the appropriate `ProviderService`. It's a wrapper for services that allows us to think of the exec service at a high level and level the implementation details to the specific underlying services (`Lambda Labs` and `Unweave`) .