### PR TITLE
Volume Database Migration + Service Layer

### DIFF
--- a/api/router/volume.go
+++ b/api/router/volume.go
@@ -4,6 +4,9 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/render"
+	"github.com/unweave/unweave/api/middleware"
+	"github.com/unweave/unweave/api/types"
 	"github.com/unweave/unweave/services/volumesrv"
 )
 
@@ -37,21 +40,80 @@ func (v *VolumeRouter) Routes() []Route {
 }
 
 func (v *VolumeRouter) VolumeCreateHandler(w http.ResponseWriter, r *http.Request) {
+	projectID := middleware.GetProjectIDFromContext(r.Context())
 
+	pcr := &types.VolumeCreateRequest{}
+	if err := render.Bind(r, pcr); err != nil {
+		render.Render(w, r, types.ErrHTTPBadRequest(err, "Failed to parse request"))
+		return
+	}
+
+	created, err := v.uwService.Create(r.Context(), projectID, pcr.Name, pcr.Size)
+	if err != nil {
+		return
+	}
+
+	render.JSON(w, r, created)
 }
 
 func (v *VolumeRouter) VolumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	projectID := middleware.GetProjectIDFromContext(r.Context())
 
+	pcr := &types.VolumeDeleteRequest{}
+	if err := render.Bind(r, pcr); err != nil {
+		render.Render(w, r, types.ErrHTTPBadRequest(err, "Failed to parse request"))
+		return
+	}
+
+	err := v.uwService.Delete(r.Context(), projectID, pcr.IDOrName)
+	if err != nil {
+		return
+	}
+
+	render.Status(r, 200)
 }
 
 func (v *VolumeRouter) VolumeGetHandler(w http.ResponseWriter, r *http.Request) {
+	projectID := middleware.GetProjectIDFromContext(r.Context())
 
+	pcr := &types.VolumeDeleteRequest{}
+	if err := render.Bind(r, pcr); err != nil {
+		render.Render(w, r, types.ErrHTTPBadRequest(err, "Failed to parse request"))
+		return
+	}
+
+	vol, err := v.uwService.Get(r.Context(), projectID, pcr.IDOrName)
+	if err != nil {
+		return
+	}
+
+	render.JSON(w, r, vol)
 }
 
 func (v *VolumeRouter) VolumeListHandler(w http.ResponseWriter, r *http.Request) {
+	projectID := middleware.GetProjectIDFromContext(r.Context())
 
+	vol, err := v.uwService.List(r.Context(), projectID)
+	if err != nil {
+		return
+	}
+
+	render.JSON(w, r, vol)
 }
 
 func (v *VolumeRouter) VolumeResizeHandler(w http.ResponseWriter, r *http.Request) {
+	projectID := middleware.GetProjectIDFromContext(r.Context())
 
+	pcr := &types.VolumeResizeRequest{}
+	if err := render.Bind(r, pcr); err != nil {
+		render.Render(w, r, types.ErrHTTPBadRequest(err, "Failed to parse request"))
+		return
+	}
+
+	err := v.uwService.Resize(r.Context(), projectID, pcr.IDOrName, pcr.Size)
+	if err != nil {
+		return
+	}
+
+	render.Status(r, 200)
 }

--- a/api/router/volume.go
+++ b/api/router/volume.go
@@ -44,13 +44,13 @@ func (v *VolumeRouter) VolumeCreateHandler(w http.ResponseWriter, r *http.Reques
 	ctx := r.Context()
 	projectID := middleware.GetProjectIDFromContext(r.Context())
 
-	pcr := &types.VolumeCreateRequest{}
-	if err := render.Bind(r, pcr); err != nil {
+	vcr := &types.VolumeCreateRequest{}
+	if err := render.Bind(r, vcr); err != nil {
 		render.Render(w, r, types.ErrHTTPBadRequest(err, "Failed to parse request"))
 		return
 	}
 
-	vol, err := v.uwService.Create(r.Context(), projectID, pcr.Name, pcr.Size)
+	vol, err := v.uwService.Create(r.Context(), projectID, vcr.Name, vcr.Size)
 	if err != nil {
 		err = fmt.Errorf("failed to create volume, %w", err)
 		render.Render(w, r.WithContext(ctx), types.ErrHTTPError(err, "Failed to create volume"))
@@ -62,32 +62,27 @@ func (v *VolumeRouter) VolumeCreateHandler(w http.ResponseWriter, r *http.Reques
 func (v *VolumeRouter) VolumeDeleteHandler(w http.ResponseWriter, r *http.Request) {
 	projectID := middleware.GetProjectIDFromContext(r.Context())
 
-	pcr := &types.VolumeDeleteRequest{}
-	if err := render.Bind(r, pcr); err != nil {
+	vdr := &types.VolumeDeleteRequest{}
+	if err := render.Bind(r, vdr); err != nil {
 		render.Render(w, r, types.ErrHTTPBadRequest(err, "Failed to parse request"))
 		return
 	}
 
-	err := v.uwService.Delete(r.Context(), projectID, pcr.IDOrName)
+	err := v.uwService.Delete(r.Context(), projectID, vdr.IDOrName)
 	if err != nil {
 		err = fmt.Errorf("failed to delete volume, %w", err)
 		render.Render(w, r, types.ErrHTTPError(err, "Failed to delete volume"))
 		return
 	}
 
-	render.Status(r, 200)
+	render.Status(r, http.StatusOK)
 }
 
 func (v *VolumeRouter) VolumeGetHandler(w http.ResponseWriter, r *http.Request) {
 	projectID := middleware.GetProjectIDFromContext(r.Context())
+	idOrName := chi.URLParam(r, "idOrName")
 
-	pcr := &types.VolumeDeleteRequest{}
-	if err := render.Bind(r, pcr); err != nil {
-		render.Render(w, r, types.ErrHTTPBadRequest(err, "Failed to parse request"))
-		return
-	}
-
-	vol, err := v.uwService.Get(r.Context(), projectID, pcr.IDOrName)
+	vol, err := v.uwService.Get(r.Context(), projectID, idOrName)
 	if err != nil {
 		err = fmt.Errorf("failed to get volume, %w", err)
 		render.Render(w, r, types.ErrHTTPError(err, "Failed to get volume"))
@@ -113,13 +108,13 @@ func (v *VolumeRouter) VolumeListHandler(w http.ResponseWriter, r *http.Request)
 func (v *VolumeRouter) VolumeResizeHandler(w http.ResponseWriter, r *http.Request) {
 	projectID := middleware.GetProjectIDFromContext(r.Context())
 
-	pcr := &types.VolumeResizeRequest{}
-	if err := render.Bind(r, pcr); err != nil {
+	vrr := &types.VolumeResizeRequest{}
+	if err := render.Bind(r, vrr); err != nil {
 		render.Render(w, r, types.ErrHTTPBadRequest(err, "Failed to parse request"))
 		return
 	}
 
-	err := v.uwService.Resize(r.Context(), projectID, pcr.IDOrName, pcr.Size)
+	err := v.uwService.Resize(r.Context(), projectID, vrr.IDOrName, vrr.Size)
 	if err != nil {
 		err = fmt.Errorf("failed to resize volume, %w", err)
 		render.Render(w, r, types.ErrHTTPError(err, "Failed to resize volume"))

--- a/api/types/volume.go
+++ b/api/types/volume.go
@@ -1,40 +1,16 @@
 package types
 
 import (
-	"fmt"
 	"net/http"
-	"strings"
 	"time"
-
-	"github.com/unweave/unweave/tools/random"
 )
 
 type Volume struct {
-	ID       string       `json:"id"`
-	Name     string       `json:"name"`
-	Size     int          `json:"size"`
-	State    *VolumeState `json:"state"`
-	Provider Provider     `json:"provider"`
-}
-
-func NewVolume(name string, size int, provider Provider) (Volume, error) {
-	rand, err := random.GenerateRandomString(11)
-	if err != nil {
-		return Volume{}, fmt.Errorf("failed to generate random string, %w", err)
-	}
-	// not a cryptographically safe identifier, but consistent with execs
-	volID := "vol_" + strings.ToLower(rand)
-
-	return Volume{
-		ID:   volID,
-		Name: name,
-		Size: size,
-		State: &VolumeState{
-			CreatedAt: time.Now().UTC(),
-			UpdatedAt: time.Now().UTC(),
-		},
-		Provider: provider,
-	}, nil
+	ID       string      `json:"id"`
+	Name     string      `json:"name"`
+	Size     int         `json:"size"`
+	State    VolumeState `json:"state"`
+	Provider Provider    `json:"provider"`
 }
 
 type VolumeState struct {

--- a/api/types/volume.go
+++ b/api/types/volume.go
@@ -1,6 +1,13 @@
 package types
 
-import "time"
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/unweave/unweave/tools/random"
+)
 
 type Volume struct {
 	ID       string       `json:"id"`
@@ -8,6 +15,26 @@ type Volume struct {
 	Size     int          `json:"size"`
 	State    *VolumeState `json:"state"`
 	Provider Provider     `json:"provider"`
+}
+
+func NewVolume(name string, size int, provider Provider) (Volume, error) {
+	rand, err := random.GenerateRandomString(11)
+	if err != nil {
+		return Volume{}, fmt.Errorf("failed to generate random string, %w", err)
+	}
+	// not a cryptographically safe identifier, but consistent with execs
+	volID := "vol_" + strings.ToLower(rand)
+
+	return Volume{
+		ID:   volID,
+		Name: name,
+		Size: size,
+		State: &VolumeState{
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		},
+		Provider: provider,
+	}, nil
 }
 
 type VolumeState struct {
@@ -19,4 +46,66 @@ type VolumeCreateRequest struct {
 	Size     int      `json:"size"`
 	Name     string   `json:"name"`
 	Provider Provider `json:"provider"`
+}
+
+func (p *VolumeCreateRequest) Bind(r *http.Request) error {
+	if p.Name == "" {
+		return &Error{
+			Code:    http.StatusBadRequest,
+			Message: "Name is required",
+		}
+	}
+
+	if p.Size <= 0 {
+		return &Error{
+			Code:    http.StatusBadRequest,
+			Message: "Size is required",
+		}
+	}
+
+	if p.Provider != UnweaveProvider { // Lambda Labs not implemented
+		return &Error{
+			Code:    http.StatusBadRequest,
+			Message: "Provider is required",
+		}
+	}
+	return nil
+}
+
+type VolumeDeleteRequest struct {
+	IDOrName string `json:"idOrName"`
+}
+
+func (p *VolumeDeleteRequest) Bind(r *http.Request) error {
+	if p.IDOrName == "" {
+		return &Error{
+			Code:    http.StatusBadRequest,
+			Message: "Name is required",
+		}
+	}
+
+	return nil
+}
+
+type VolumeResizeRequest struct {
+	IDOrName string `json:"idOrName"`
+	Size     int    `json:"size"`
+}
+
+func (p *VolumeResizeRequest) Bind(r *http.Request) error {
+	if p.IDOrName == "" {
+		return &Error{
+			Code:    http.StatusBadRequest,
+			Message: "Name is required",
+		}
+	}
+
+	if p.Size <= 0 {
+		return &Error{
+			Code:    http.StatusBadRequest,
+			Message: "A new size is required",
+		}
+	}
+
+	return nil
 }

--- a/db/migrations/20230614145615_add_size_to_volume.sql
+++ b/db/migrations/20230614145615_add_size_to_volume.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE unweave.volume ADD COLUMN size integer NOT NULL DEFAULT 0;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+select 'down SQL query';
+-- +goose StatementEnd

--- a/db/models.go
+++ b/db/models.go
@@ -194,4 +194,5 @@ type UnweaveVolume struct {
 	Provider  string    `json:"provider"`
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
+	Size      int32     `json:"size"`
 }

--- a/db/querier.go
+++ b/db/querier.go
@@ -42,8 +42,9 @@ type Querier interface {
 	SSHKeysGetByIDs(ctx context.Context, ids []string) ([]UnweaveSshKey, error)
 	VolumeCreate(ctx context.Context, arg VolumeCreateParams) (UnweaveVolume, error)
 	VolumeDelete(ctx context.Context, id string) error
-	VolumeGet(ctx context.Context, id string) (UnweaveVolume, error)
+	VolumeGet(ctx context.Context, arg VolumeGetParams) (UnweaveVolume, error)
 	VolumeList(ctx context.Context, projectID string) ([]UnweaveVolume, error)
+	VolumeUpdate(ctx context.Context, arg VolumeUpdateParams) error
 }
 
 var _ Querier = (*Queries)(nil)

--- a/db/queries/volume.sql
+++ b/db/queries/volume.sql
@@ -9,8 +9,13 @@ where id = $1;
 
 -- name: VolumeGet :one
 select * from unweave.volume
-where id = $1;
+where project_id = $1 and (id = $2 or name = $2);
 
 -- name: VolumeList :many
 select * from unweave.volume
 where project_id = $1;
+
+-- name: VolumeUpdate :exec
+update unweave.volume
+set size = $2
+where id = $1;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -171,7 +171,8 @@ CREATE TABLE unweave.volume (
     project_id text NOT NULL,
     provider text NOT NULL,
     created_at timestamp without time zone DEFAULT now() NOT NULL,
-    updated_at timestamp without time zone DEFAULT now() NOT NULL
+    updated_at timestamp without time zone DEFAULT now() NOT NULL,
+    size integer DEFAULT 0 NOT NULL
 );
 
 ALTER TABLE unweave.volume OWNER TO postgres;

--- a/services/volumesrv/convert.go
+++ b/services/volumesrv/convert.go
@@ -10,7 +10,7 @@ func volumeFromDB(volume db.UnweaveVolume) types.Volume {
 		ID:   volume.ID,
 		Name: volume.Name,
 		Size: int(volume.Size),
-		State: &types.VolumeState{
+		State: types.VolumeState{
 			CreatedAt: volume.CreatedAt,
 			UpdatedAt: volume.UpdatedAt,
 		},

--- a/services/volumesrv/convert.go
+++ b/services/volumesrv/convert.go
@@ -7,12 +7,13 @@ import (
 
 func volumeFromDB(volume db.UnweaveVolume) types.Volume {
 	return types.Volume{
-		ID:       volume.ID,
-		Name:     volume.Name,
-		Provider: types.Provider(volume.Provider),
+		ID:   volume.ID,
+		Name: volume.Name,
+		Size: int(volume.Size),
 		State: &types.VolumeState{
 			CreatedAt: volume.CreatedAt,
 			UpdatedAt: volume.UpdatedAt,
 		},
+		Provider: types.Provider(volume.Provider),
 	}
 }

--- a/services/volumesrv/convert.go
+++ b/services/volumesrv/convert.go
@@ -1,0 +1,18 @@
+package volumesrv
+
+import (
+	"github.com/unweave/unweave/api/types"
+	"github.com/unweave/unweave/db"
+)
+
+func volumeFromDB(volume db.UnweaveVolume) types.Volume {
+	return types.Volume{
+		ID:       volume.ID,
+		Name:     volume.Name,
+		Provider: types.Provider(volume.Provider),
+		State: &types.VolumeState{
+			CreatedAt: volume.CreatedAt,
+			UpdatedAt: volume.UpdatedAt,
+		},
+	}
+}

--- a/services/volumesrv/service.go
+++ b/services/volumesrv/service.go
@@ -38,7 +38,10 @@ func (s *Service) Create(ctx context.Context, projectID, name string, size int) 
 
 	err = s.store.VolumeAdd(projectID, v)
 	if err != nil {
-		s.driver.VolumeDelete(ctx, v.ID)
+		err := s.driver.VolumeDelete(ctx, v.ID)
+		if err != nil {
+			return types.Volume{}, err
+		}
 		return types.Volume{}, err
 	}
 
@@ -79,6 +82,7 @@ func (s *Service) List(ctx context.Context, projectID string) ([]types.Volume, e
 	if err != nil {
 		return vols, err
 	}
+
 	return vols, nil
 }
 
@@ -87,6 +91,7 @@ func (s *Service) Resize(ctx context.Context, projectID, idOrName string, size i
 	if err != nil {
 		return err
 	}
+
 	if vol.Size == size {
 		return nil
 	}
@@ -95,10 +100,13 @@ func (s *Service) Resize(ctx context.Context, projectID, idOrName string, size i
 
 	err = s.driver.VolumeUpdate(ctx, vol)
 	if err != nil {
-		return nil
+		return err
 	}
 
-	s.store.VolumeUpdate(vol.ID, vol)
+	err = s.store.VolumeUpdate(vol.ID, vol)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/services/volumesrv/service.go
+++ b/services/volumesrv/service.go
@@ -20,22 +20,58 @@ func NewService(store Store, driver Driver) *Service {
 	}
 }
 
-func (s *Service) Create(ctx context.Context) (string, error) {
-	return "", nil
+func (s *Service) Create(ctx context.Context, projectID, name string, size int) (types.Volume, error) {
+	err := s.driver.VolumeCreate(ctx, name, size)
+	if err != nil {
+		return types.Volume{}, err
+	}
+
+	v, err := s.driver.VolumeGet(ctx, name)
+	if err != nil {
+		return types.Volume{}, err
+	}
+
+	err = s.store.VolumeAdd(projectID, v)
+	if err != nil {
+		s.driver.VolumeDelete(ctx, v.ID)
+		return types.Volume{}, err
+	}
+
+	return v, nil
 }
 
-func (s *Service) Delete(ctx context.Context) error {
+func (s *Service) Delete(ctx context.Context, id string) error {
+	err := s.driver.VolumeDelete(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	err = s.store.VolumeDelete(id)
+	if err != nil {
+		// infers a case where a user is being billed for a volume that does not exist
+		return err
+	}
+
 	return nil
 }
 
-func (s *Service) Get(ctx context.Context) (types.Volume, error) {
-	return types.Volume{}, nil
+func (s *Service) Get(ctx context.Context, projectID, idOrName string) (types.Volume, error) {
+	volume, err := s.store.VolumeGet(projectID, idOrName)
+	if err != nil {
+		return types.Volume{}, err
+	}
+
+	return volume, nil
 }
 
-func (s *Service) List(ctx context.Context) ([]types.Volume, error) {
-	return []types.Volume{}, nil
+func (s *Service) List(ctx context.Context, projectID string) ([]types.Volume, error) {
+	vols, err := s.store.VolumeList(projectID)
+	if err != nil {
+		return vols, err
+	}
+	return vols, nil
 }
 
-func (s *Service) Resize(ctx context.Context) error {
+func (s *Service) Resize(ctx context.Context, id string, size int) error {
 	return nil
 }

--- a/services/volumesrv/service.go
+++ b/services/volumesrv/service.go
@@ -39,7 +39,7 @@ func (s *Service) Create(ctx context.Context, projectID, name string, size int) 
 		Provider: s.provider,
 	}
 
-	err = s.store.VolumeAdd(projectID, v)
+	err = s.store.VolumeAdd(projectID, v.ID, v.Provider)
 	if err != nil {
 		err = fmt.Errorf("failed to add volume to store: %w", err)
 

--- a/services/volumesrv/store.go
+++ b/services/volumesrv/store.go
@@ -1,7 +1,13 @@
 package volumesrv
 
 import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/http"
+
 	"github.com/unweave/unweave/api/types"
+	"github.com/unweave/unweave/db"
 )
 
 type postgresStore struct{}
@@ -11,21 +17,85 @@ func NewPostgresStore() Store {
 }
 
 func (p postgresStore) VolumeAdd(projectID string, volume types.Volume) error {
-	//TODO implement me
-	panic("implement me")
+	ctx := context.Background()
+	_, err := db.Q.VolumeCreate(ctx, db.VolumeCreateParams{
+		ID:        volume.ID,
+		ProjectID: projectID,
+		Provider:  volume.Provider.String(),
+	})
+	if err != nil {
+		return &types.Error{
+			Code:    http.StatusBadRequest,
+			Message: "Volume could not be created",
+			Err:     err,
+		}
+	}
+
+	return nil
+}
+
+func (p postgresStore) VolumeList(projectID string) ([]types.Volume, error) {
+	vols, err := db.Q.VolumeList(context.Background(), projectID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get volumes from db: %w", err)
+	}
+
+	out := make([]types.Volume, 0, len(vols))
+	for _, v := range vols {
+		out = append(out, volumeFromDB(v))
+	}
+
+	return out, nil
 }
 
 func (p postgresStore) VolumeGet(projectID, idOrName string) (types.Volume, error) {
-	//TODO implement me
-	panic("implement me")
+	vol, err := db.Q.VolumeGet(context.Background(), db.VolumeGetParams{
+		ProjectID: projectID,
+		ID:        idOrName,
+	})
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return types.Volume{}, &types.Error{
+				Code:    http.StatusBadRequest,
+				Message: "Volume not found",
+				Err:     err,
+			}
+		}
+		return types.Volume{}, fmt.Errorf("failed to get volume from db: %w", err)
+	}
+
+	return volumeFromDB(vol), nil
 }
 
-func (p postgresStore) VolumeDelete(id string) {
-	//TODO implement me
-	panic("implement me")
+func (p postgresStore) VolumeDelete(id string) error {
+	ctx := context.Background()
+	if err := db.Q.VolumeDelete(ctx, id); err != nil {
+		return &types.Error{
+			Code:    http.StatusBadRequest,
+			Message: "Volume could not be deleted",
+			Err:     err,
+		}
+	}
+
+	return nil
 }
 
 func (p postgresStore) VolumeUpdate(id string, volume types.Volume) error {
-	//TODO implement me
-	panic("implement me")
+	ctx := context.Background()
+	err := db.Q.VolumeUpdate(ctx, db.VolumeUpdateParams{
+		ID:   id,
+		Size: int32(volume.Size),
+	})
+	if err != nil {
+		return &types.Error{
+			Code:    http.StatusBadRequest,
+			Message: "Volume could not be updated",
+			Err:     err,
+		}
+	}
+
+	return nil
 }

--- a/services/volumesrv/volume.go
+++ b/services/volumesrv/volume.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Store interface {
-	VolumeAdd(projectID string, volume types.Volume) error
+	VolumeAdd(projectID string, id string, provider types.Provider) error
 	VolumeList(projectID string) ([]types.Volume, error)
 	VolumeGet(projectID, idOrName string) (types.Volume, error)
 	VolumeDelete(id string) error

--- a/services/volumesrv/volume.go
+++ b/services/volumesrv/volume.go
@@ -8,14 +8,15 @@ import (
 
 type Store interface {
 	VolumeAdd(projectID string, volume types.Volume) error
+	VolumeList(projectID string) ([]types.Volume, error)
 	VolumeGet(projectID, idOrName string) (types.Volume, error)
-	VolumeDelete(id string)
+	VolumeDelete(id string) error
 	VolumeUpdate(id string, volume types.Volume) error
 }
 
 type Driver interface {
-	VolumeCreate(ctx context.Context, name string, size int)
-	VolumeDelete(ctx context.Context, id string)
+	VolumeCreate(ctx context.Context, name string, size int) error
+	VolumeDelete(ctx context.Context, id string) error
 	VolumeGet(ctx context.Context, id string) (types.Volume, error)
 	VolumeProvider() types.Provider
 	VolumeDriver(ctx context.Context) string

--- a/services/volumesrv/volume.go
+++ b/services/volumesrv/volume.go
@@ -15,9 +15,8 @@ type Store interface {
 }
 
 type Driver interface {
-	VolumeCreate(ctx context.Context, vol types.Volume) error
+	VolumeCreate(ctx context.Context, size int) (string, error)
 	VolumeDelete(ctx context.Context, id string) error
-	VolumeGet(ctx context.Context, id string) (types.Volume, error)
 	VolumeProvider() types.Provider
 	VolumeDriver(ctx context.Context) string
 	VolumeUpdate(ctx context.Context, vol types.Volume) error

--- a/services/volumesrv/volume.go
+++ b/services/volumesrv/volume.go
@@ -15,10 +15,10 @@ type Store interface {
 }
 
 type Driver interface {
-	VolumeCreate(ctx context.Context, name string, size int) error
+	VolumeCreate(ctx context.Context, vol types.Volume) error
 	VolumeDelete(ctx context.Context, id string) error
 	VolumeGet(ctx context.Context, id string) (types.Volume, error)
 	VolumeProvider() types.Provider
 	VolumeDriver(ctx context.Context) string
-	VolumeResize(ctx context.Context, id string, size int) error
+	VolumeUpdate(ctx context.Context, vol types.Volume) error
 }


### PR DESCRIPTION
This PR adds the database migrations needed to represent the size of a volume in the DB (gigabytes) and the service layer implementation. Creations work fine but will hold off on further E2E tests until the structure of the code has been reviewed and decided on.