### PR TITLE
SSH Key Names should not contain the '.pub' suffix

### DIFF
--- a/services/sshkeys/service.go
+++ b/services/sshkeys/service.go
@@ -48,7 +48,7 @@ func (s *Service) Add(ctx context.Context, userID string, params types.SSHKeyAdd
 	}
 
 	if name == "" {
-		name = "uw:" + random.GenerateRandomPhrase(4, "-") + ".pub"
+		name = "uw:" + random.GenerateRandomPhrase(4, "-")
 	}
 
 	err := s.store.SSHKeyAdd(ctx, userID, name, params.PublicKey)


### PR DESCRIPTION
This PR fixes UNW-206 where an extra 'pub' suffix was appended to each SSH key name. SSH Key names are distinct from public key filenames and private key filenames. This caused an issue where public keys with filenames based on the SSH key name were appended with an extra .pub suffix, and an issue where the private key was created with a public key filename suffix.