### PR TITLE
Fix service initialization caused by incorrect function options order 

### DIFF
--- a/api/types/model.go
+++ b/api/types/model.go
@@ -18,6 +18,7 @@ const (
 	StatusError        Status = "error"
 	StatusFailed       Status = "failed"
 	StatusSuccess      Status = "success"
+	StatusUnknown      Status = "unknown"
 )
 
 type NoOpLogHook struct{}

--- a/main.go
+++ b/main.go
@@ -50,11 +50,12 @@ func main() {
 	volumeStore := volumesrv.NewPostgresStore()
 	llVolumeSrv := volumesrv.NewService(volumeStore, llDriver)
 
-	lls, err := execsrv.NewService(execStore, llDriver, llVolumeSrv, llStateInf, llStatsInf, llHeartbeatInf)
-	if err != nil {
+	lls := execsrv.NewService(execStore, llDriver, llVolumeSrv, llStateInf, llStatsInf, llHeartbeatInf)
+	lls = execsrv.WithStateObserver(lls, execsrv.NewStateObserverFunc(lls))
+
+	if err = lls.Init(); err != nil {
 		panic(err)
 	}
-	lls = execsrv.WithStateObserver(lls, execsrv.NewStateObserverFunc(lls))
 
 	execRouter := router.NewExecRouter(execStore, lls, nil)
 	sshKeysRouter := router.NewSSHKeysRouter(sshkeys.NewService())

--- a/services/execsrv/service.go
+++ b/services/execsrv/service.go
@@ -68,65 +68,6 @@ func NewService(
 	return s
 }
 
-func (s *ExecService) Init() error {
-	execs, err := s.store.List(nil, &s.provider, true)
-	if err != nil {
-		return fmt.Errorf("failed to init StateInformer, failed list all execs: %w", err)
-	}
-
-	log.Info().
-		Str(types.ProviderCtxKey, s.provider.String()).
-		Msgf("Found %d existing execs", len(execs))
-
-	for _, exec := range execs {
-		e := exec
-
-		ed, err := s.store.GetDriver(e.ID)
-		if err != nil {
-			return fmt.Errorf("failed to init StateInformer, failed get exec driver: %w", err)
-		}
-
-		if ed != s.driver.ExecDriverName() {
-			continue
-		}
-
-		informer := s.stateInformerFunc(e)
-		informer.Watch()
-
-		for _, f := range s.stateObserversFuncs {
-			o := f(e, informer)
-			informer.Register(o)
-		}
-
-		if e.Status == types.StatusRunning {
-			if err = s.Monitor(context.Background(), exec.ID); err != nil {
-				log.Error().
-					Err(err).
-					Str(types.ExecIDCtxKey, exec.ID).
-					Msg("Failed to monitor exec")
-			}
-		}
-	}
-	return nil
-}
-
-func (s *ExecService) parseVolumes(ctx context.Context, projectID string, volumes []types.VolumeAttachParams) ([]types.ExecVolume, error) {
-	vols := make([]types.ExecVolume, len(volumes))
-
-	for idx, v := range volumes {
-		vol, err := s.volume.Get(ctx, projectID, v.VolumeRef)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get volume %q: %w", v.VolumeRef, err)
-		}
-
-		vols[idx] = types.ExecVolume{
-			VolumeID:  vol.ID,
-			MountPath: v.MountPath,
-		}
-	}
-	return vols, nil
-}
-
 func (s *ExecService) Create(ctx context.Context, projectID string, creator string, params types.ExecCreateParams) (types.Exec, error) {
 	image := DefaultImageURI
 	if params.Image != nil && *params.Image != "" {
@@ -198,12 +139,69 @@ func (s *ExecService) Get(ctx context.Context, id string) (types.Exec, error) {
 	return exec, err
 }
 
+func (s *ExecService) Init() error {
+	execs, err := s.store.List(nil, &s.provider, true)
+	if err != nil {
+		return fmt.Errorf("failed to init StateInformer, failed list all execs: %w", err)
+	}
+
+	log.Info().
+		Str(types.ProviderCtxKey, s.provider.String()).
+		Msgf("Found %d existing execs", len(execs))
+
+	for _, exec := range execs {
+		driver, err := s.store.GetDriver(exec.ID)
+		if err != nil {
+			return fmt.Errorf("failed to init StateInformer, failed get exec driver: %w", err)
+		}
+
+		if driver != s.driver.ExecDriverName() {
+			continue
+		}
+
+		informer := s.stateInformerFunc(exec)
+		informer.Watch()
+
+		for _, f := range s.stateObserversFuncs {
+			o := f(exec, informer)
+			informer.Register(o)
+		}
+
+		if exec.Status == types.StatusRunning {
+			if err = s.Monitor(context.Background(), exec.ID); err != nil {
+				log.Error().
+					Err(err).
+					Str(types.ExecIDCtxKey, exec.ID).
+					Msg("Failed to monitor exec")
+			}
+		}
+	}
+	return nil
+}
+
 func (s *ExecService) List(ctx context.Context, project string) ([]types.Exec, error) {
 	execs, err := s.store.List(&project, &s.provider, false)
 	if err != nil {
 		return nil, err
 	}
 	return execs, nil
+}
+
+func (s *ExecService) parseVolumes(ctx context.Context, projectID string, volumes []types.VolumeAttachParams) ([]types.ExecVolume, error) {
+	vols := make([]types.ExecVolume, len(volumes))
+
+	for idx, v := range volumes {
+		vol, err := s.volume.Get(ctx, projectID, v.VolumeRef)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get volume %q: %w", v.VolumeRef, err)
+		}
+
+		vols[idx] = types.ExecVolume{
+			VolumeID:  vol.ID,
+			MountPath: v.MountPath,
+		}
+	}
+	return vols, nil
 }
 
 func (s *ExecService) Terminate(ctx context.Context, id string) error {


### PR DESCRIPTION
The exec service was being initialized incorrectly. It expected the observes to already be registered on calling the `NewService` constructor.

The informer implementation is currently buggy: it allows you to register the same informer multiple times. I'll fix this in another PR