### PR TITLE
Fix error when passing a command and no source context

### DIFF
--- a/api/types/http.go
+++ b/api/types/http.go
@@ -183,7 +183,7 @@ func (s *ExecCreateParams) Bind(r *http.Request) error {
 		}
 	}
 
-	if s.Command != nil {
+	if s.Source != nil {
 		part, err := parseContextFile(r)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fix a problem where the API expected a source context uploaded if a command was passed. Change this so that a source context is only required when the source block is passed, not the command.