### PR TITLE
DRY up setting terminated_at to the UpdateStatus function

### DIFF
--- a/db/models.go
+++ b/db/models.go
@@ -189,11 +189,11 @@ type UnweaveSshKey struct {
 
 type UnweaveVolume struct {
 	ID        string       `json:"id"`
-	Size      int32        `json:"size"`
 	Name      string       `json:"name"`
 	ProjectID string       `json:"projectID"`
 	Provider  string       `json:"provider"`
 	CreatedAt time.Time    `json:"createdAt"`
 	UpdatedAt time.Time    `json:"updatedAt"`
+	Size      int32        `json:"size"`
 	DeletedAt sql.NullTime `json:"deletedAt"`
 }

--- a/db/types.go
+++ b/db/types.go
@@ -1,10 +1,20 @@
 package db
 
-import "database/sql"
+import (
+	"database/sql"
+	"time"
+)
 
 func NullStringFrom(s *string) sql.NullString {
 	if s == nil {
 		return sql.NullString{}
 	}
 	return sql.NullString{String: *s, Valid: true}
+}
+
+func NullTimeFrom(t time.Time) sql.NullTime {
+	return sql.NullTime{
+		Time:  t,
+		Valid: !t.IsZero(),
+	}
 }

--- a/db/volume.sql.go
+++ b/db/volume.sql.go
@@ -12,7 +12,7 @@ import (
 const VolumeCreate = `-- name: VolumeCreate :one
 insert into unweave.volume (id, project_id, provider, name, size)
 values($1, $2, $3, $4, $5)
-returning id, size, name, project_id, provider, created_at, updated_at, deleted_at
+returning id, name, project_id, provider, created_at, updated_at, size, deleted_at
 `
 
 type VolumeCreateParams struct {
@@ -34,12 +34,12 @@ func (q *Queries) VolumeCreate(ctx context.Context, arg VolumeCreateParams) (Unw
 	var i UnweaveVolume
 	err := row.Scan(
 		&i.ID,
-		&i.Size,
 		&i.Name,
 		&i.ProjectID,
 		&i.Provider,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Size,
 		&i.DeletedAt,
 	)
 	return i, err
@@ -56,7 +56,7 @@ func (q *Queries) VolumeDelete(ctx context.Context, id string) error {
 }
 
 const VolumeGet = `-- name: VolumeGet :one
-select id, size, name, project_id, provider, created_at, updated_at, deleted_at from unweave.volume
+select id, name, project_id, provider, created_at, updated_at, size, deleted_at from unweave.volume
 where project_id = $1 and (id = $2 or name = $2)
 `
 
@@ -70,19 +70,19 @@ func (q *Queries) VolumeGet(ctx context.Context, arg VolumeGetParams) (UnweaveVo
 	var i UnweaveVolume
 	err := row.Scan(
 		&i.ID,
-		&i.Size,
 		&i.Name,
 		&i.ProjectID,
 		&i.Provider,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+		&i.Size,
 		&i.DeletedAt,
 	)
 	return i, err
 }
 
 const VolumeList = `-- name: VolumeList :many
-select id, size, name, project_id, provider, created_at, updated_at, deleted_at from unweave.volume
+select id, name, project_id, provider, created_at, updated_at, size, deleted_at from unweave.volume
 where project_id = $1
 `
 
@@ -97,12 +97,12 @@ func (q *Queries) VolumeList(ctx context.Context, projectID string) ([]UnweaveVo
 		var i UnweaveVolume
 		if err := rows.Scan(
 			&i.ID,
-			&i.Size,
 			&i.Name,
 			&i.ProjectID,
 			&i.Provider,
 			&i.CreatedAt,
 			&i.UpdatedAt,
+			&i.Size,
 			&i.DeletedAt,
 		); err != nil {
 			return nil, err

--- a/services/execsrv/exec.go
+++ b/services/execsrv/exec.go
@@ -3,6 +3,7 @@ package execsrv
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/unweave/unweave/api/types"
 )
@@ -19,7 +20,7 @@ type Store interface {
 	List(filterProject *string, filterProvider *types.Provider, filterActive bool) ([]types.Exec, error)
 	Delete(id string) error
 	Update(id string, exec types.Exec) error
-	UpdateStatus(id string, status types.Status) error
+	UpdateStatus(id string, status types.Status, setReadyAt, setExitedAt time.Time) error
 }
 
 type Driver interface {


### PR DESCRIPTION
there's a bug where execs were marked as ready but not as terminated. this pull request addresses the issue by updating the store's update status method to set terminated_at if non-zero. another pr in unweave's internal infrastructure will address the lack of consistency to prevent future regressions.