### PR TITLE
feat: Return status and conclusion for checks and check steps

### DIFF
--- a/api/types/endpoint.go
+++ b/api/types/endpoint.go
@@ -85,7 +85,7 @@ type EndpointCheck struct {
 	CheckID    string
 	Steps      []EndpointCheckStep
 	Status     CheckStatus
-	Conclusion *CheckConclusion `json:",omitempty"`
+	Conclusion *CheckConclusion `json:"conclusion,omitempty"`
 }
 
 type EndpointCheckStep struct {
@@ -95,5 +95,5 @@ type EndpointCheckStep struct {
 	Output     json.RawMessage
 	Assertion  string
 	Status     CheckStatus
-	Conclusion *CheckConclusion `json:",omitempty"`
+	Conclusion *CheckConclusion `json:"conclusion,omitempty"`
 }

--- a/api/types/endpoint.go
+++ b/api/types/endpoint.go
@@ -82,14 +82,18 @@ type EndpointCheckRun struct {
 }
 
 type EndpointCheck struct {
-	CheckID string
-	Steps   []EndpointCheckStep
+	CheckID    string
+	Steps      []EndpointCheckStep
+	Status     CheckStatus
+	Conclusion *CheckConclusion `json:",omitempty"`
 }
 
 type EndpointCheckStep struct {
-	StepID    string
-	EvalID    string
-	Input     json.RawMessage
-	Output    json.RawMessage
-	Assertion string
+	StepID     string
+	EvalID     string
+	Input      json.RawMessage
+	Output     json.RawMessage
+	Assertion  string
+	Status     CheckStatus
+	Conclusion *CheckConclusion `json:",omitempty"`
 }

--- a/api/types/model.go
+++ b/api/types/model.go
@@ -219,3 +219,23 @@ type VolumeState struct {
 	CreatedAt time.Time `json:"createdAt"`
 	UpdatedAt time.Time `json:"updatedAt"`
 }
+
+type CheckStatus string
+
+var (
+	CheckPending    CheckStatus = "pending"
+	CheckInProgress CheckStatus = "in_progress"
+	CheckCompleted  CheckStatus = "completed"
+)
+
+type CheckConclusion string
+
+var (
+	CheckSuccess CheckConclusion = "success"
+	CheckFailure CheckConclusion = "failure"
+	CheckError   CheckConclusion = "error"
+)
+
+func (c CheckConclusion) String() string {
+	return string(c)
+}

--- a/services/endpointsrv/service.go
+++ b/services/endpointsrv/service.go
@@ -508,7 +508,7 @@ func (e *EndpointService) EndpointCheckStatus(ctx context.Context, checkID strin
 
 	out := make([]types.EndpointCheckStep, len(steps))
 	for idx, step := range steps {
-		status, conclusion := StepStatusAndConclusion(step)
+		status, conclusion := stepStatusAndConclusion(step)
 		out[idx] = types.EndpointCheckStep{
 			StepID:     step.ID,
 			EvalID:     step.EvalID,
@@ -520,7 +520,7 @@ func (e *EndpointService) EndpointCheckStatus(ctx context.Context, checkID strin
 		}
 	}
 
-	status, conclusion := CheckStatusAndConclusion(out)
+	status, conclusion := checkStatusAndConclusion(out)
 	return types.EndpointCheck{
 		CheckID:    checkID,
 		Steps:      out,
@@ -659,8 +659,8 @@ func demoteVersions(end *types.Endpoint) {
 	}
 }
 
-// StepStatusAndConclusion infers the status of a step based on the contents of the database.
-func StepStatusAndConclusion(step db.UnweaveEndpointCheckStep) (types.CheckStatus, *types.CheckConclusion) {
+// stepStatusAndConclusion infers the status of a step based on the contents of the database.
+func stepStatusAndConclusion(step db.UnweaveEndpointCheckStep) (types.CheckStatus, *types.CheckConclusion) {
 	if !step.Output.Valid {
 		return types.CheckPending, nil
 	}
@@ -681,8 +681,8 @@ func StepStatusAndConclusion(step db.UnweaveEndpointCheckStep) (types.CheckStatu
 	}
 }
 
-// CheckStatusAndConclusion infers the status of a check based on the status of the steps.
-func CheckStatusAndConclusion(steps []types.EndpointCheckStep) (types.CheckStatus, *types.CheckConclusion) {
+// checkStatusAndConclusion infers the status of a check based on the status of the steps.
+func checkStatusAndConclusion(steps []types.EndpointCheckStep) (types.CheckStatus, *types.CheckConclusion) {
 	conclusions := map[string]struct{}{}
 
 	for _, step := range steps {

--- a/services/endpointsrv/service.go
+++ b/services/endpointsrv/service.go
@@ -520,9 +520,12 @@ func (e *EndpointService) EndpointCheckStatus(ctx context.Context, checkID strin
 		}
 	}
 
+	status, conclusion := CheckStatusAndConclusion(out)
 	return types.EndpointCheck{
-		CheckID: checkID,
-		Steps:   out,
+		CheckID:    checkID,
+		Steps:      out,
+		Status:     status,
+		Conclusion: conclusion,
 	}, nil
 }
 

--- a/services/endpointsrv/service.go
+++ b/services/endpointsrv/service.go
@@ -661,6 +661,7 @@ func StepStatusAndConclusion(step db.UnweaveEndpointCheckStep) (types.CheckStatu
 	if !step.Output.Valid {
 		return types.CheckPending, nil
 	}
+
 	if !step.Assertion.Valid {
 		return types.CheckInProgress, nil
 	}
@@ -695,6 +696,7 @@ func CheckStatusAndConclusion(steps []types.EndpointCheckStep) (types.CheckStatu
 	if _, ok := conclusions[types.CheckError.String()]; ok {
 		return types.CheckCompleted, &types.CheckError
 	}
+
 	if _, ok := conclusions[types.CheckFailure.String()]; ok {
 		return types.CheckCompleted, &types.CheckFailure
 	}

--- a/services/endpointsrv/service_test.go
+++ b/services/endpointsrv/service_test.go
@@ -1,0 +1,211 @@
+package endpointsrv
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unweave/unweave/api/types"
+	"github.com/unweave/unweave/db"
+)
+
+func TestStepStatusAndConclusion(t *testing.T) {
+	builder := newDBCheckStepBuilder()
+	stepWithModelOutput := builder.withModelOutput("foo")
+
+	t.Run("pending", func(t *testing.T) {
+		step := builder.mustBuild()
+
+		status, conclusion := stepStatusAndConclusion(step)
+
+		require.Equal(t, types.CheckPending, status)
+		require.Nil(t, conclusion)
+	})
+
+	t.Run("in progress", func(t *testing.T) {
+		t.Run("no assertion", func(t *testing.T) {
+			step := stepWithModelOutput.mustBuild()
+
+			status, conclusion := stepStatusAndConclusion(step)
+
+			require.Equal(t, types.CheckInProgress, status)
+			require.Nil(t, conclusion)
+		})
+
+		t.Run("with empty assertion", func(t *testing.T) {
+			step := stepWithModelOutput.withAssertionOutput("").mustBuild()
+
+			status, conclusion := stepStatusAndConclusion(step)
+
+			require.Equal(t, types.CheckInProgress, status)
+			require.Nil(t, conclusion)
+		})
+	})
+
+	t.Run("completed", func(t *testing.T) {
+		type testCase struct {
+			name               string
+			step               func() db.UnweaveEndpointCheckStep
+			expectedConclusion types.CheckConclusion
+		}
+
+		testCases := []testCase{
+			{
+				name: "success",
+				step: func() db.UnweaveEndpointCheckStep {
+					return stepWithModelOutput.withAssertionOutput("success").mustBuild()
+				},
+				expectedConclusion: types.CheckSuccess,
+			},
+			{
+				name: "failure",
+				step: func() db.UnweaveEndpointCheckStep {
+					return stepWithModelOutput.withAssertionOutput("failure").mustBuild()
+				},
+				expectedConclusion: types.CheckFailure,
+			},
+			{
+				name: "error",
+				step: func() db.UnweaveEndpointCheckStep {
+					return stepWithModelOutput.withAssertionOutput("foo").mustBuild()
+				},
+				expectedConclusion: types.CheckError,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				step := tc.step()
+
+				status, conclusion := stepStatusAndConclusion(step)
+
+				require.Equal(t, types.CheckCompleted, status)
+				require.NotNil(t, conclusion)
+				require.Equal(t, tc.expectedConclusion, *conclusion)
+			})
+		}
+	})
+}
+
+func TestCheckStatusAndConclusion(t *testing.T) {
+	t.Run("in progress", func(t *testing.T) {
+		type testCase struct {
+			name  string
+			steps []types.EndpointCheckStep
+		}
+
+		testCases := []testCase{
+			{
+				name: "all pending",
+				steps: []types.EndpointCheckStep{
+					{Status: types.CheckPending},
+					{Status: types.CheckPending},
+					{Status: types.CheckPending},
+				},
+			},
+			{
+				name: "some in progress",
+				steps: []types.EndpointCheckStep{
+					{Status: types.CheckPending},
+					{Status: types.CheckInProgress},
+					{Status: types.CheckPending},
+				},
+			},
+			{
+				name: "some completed",
+				steps: []types.EndpointCheckStep{
+					{Status: types.CheckPending},
+					{Status: types.CheckCompleted, Conclusion: &types.CheckSuccess},
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				status, conclusion := checkStatusAndConclusion(tc.steps)
+
+				require.Equal(t, types.CheckInProgress, status)
+				require.Nil(t, conclusion)
+			})
+		}
+	})
+
+	t.Run("completed", func(t *testing.T) {
+		type testCase struct {
+			name               string
+			steps              []types.EndpointCheckStep
+			expectedConclusion types.CheckConclusion
+		}
+
+		testCases := []testCase{
+			{
+				name: "all success",
+				steps: []types.EndpointCheckStep{
+					{Status: types.CheckCompleted, Conclusion: &types.CheckSuccess},
+					{Status: types.CheckCompleted, Conclusion: &types.CheckSuccess},
+					{Status: types.CheckCompleted, Conclusion: &types.CheckSuccess},
+				},
+				expectedConclusion: types.CheckSuccess,
+			},
+			{
+				name: "some failure",
+				steps: []types.EndpointCheckStep{
+					{Status: types.CheckCompleted, Conclusion: &types.CheckSuccess},
+					{Status: types.CheckCompleted, Conclusion: &types.CheckFailure},
+					{Status: types.CheckCompleted, Conclusion: &types.CheckSuccess},
+				},
+				expectedConclusion: types.CheckFailure,
+			},
+			{
+				name: "some error",
+				steps: []types.EndpointCheckStep{
+					{Status: types.CheckCompleted, Conclusion: &types.CheckSuccess},
+					{Status: types.CheckCompleted, Conclusion: &types.CheckError},
+					{Status: types.CheckCompleted, Conclusion: &types.CheckSuccess},
+				},
+				expectedConclusion: types.CheckError,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				status, conclusion := checkStatusAndConclusion(tc.steps)
+
+				require.Equal(t, types.CheckCompleted, status)
+				require.NotNil(t, conclusion)
+				require.Equal(t, tc.expectedConclusion, *conclusion)
+			})
+		}
+	})
+}
+
+type dbEndpointCheckStepBuilder struct {
+	object db.UnweaveEndpointCheckStep
+}
+
+func newDBCheckStepBuilder() dbEndpointCheckStepBuilder {
+	return dbEndpointCheckStepBuilder{}
+}
+
+func (b dbEndpointCheckStepBuilder) withModelOutput(o string) dbEndpointCheckStepBuilder {
+	b.object.Output = sql.NullString{String: o, Valid: true}
+	return b
+}
+
+func (b dbEndpointCheckStepBuilder) withAssertionOutput(o string) dbEndpointCheckStepBuilder {
+	b.object.Assertion = sql.NullString{String: o, Valid: true}
+	return b
+}
+
+func (b dbEndpointCheckStepBuilder) build() (db.UnweaveEndpointCheckStep, error) {
+	return b.object, nil
+}
+
+func (b dbEndpointCheckStepBuilder) mustBuild() db.UnweaveEndpointCheckStep {
+	step, err := b.build()
+	if err != nil {
+		panic(err)
+	}
+
+	return step
+}


### PR DESCRIPTION
We want to provide the status of a check and the given steps.

We are following a similar API design the GitHub Checks API:
* `status`: provides information about the status of running the check/step.
* `conclusion`: once status is completed, specify whether the chec/step completed with a success/failure/error.

How it's implemented:
* Added new `CheckStatus` and `CheckConclusion` types.
* Included the `status` and `conclusion` in the returned API types.
* Added some logic to infer the status and conclusion based on the step information in the database.

For future PRs:
* Update CLI to show the status/conclusion.
* Persisting status and conclusion in the database.