### PR TITLE
Add name to endpoints

### DIFF
--- a/api/router/endpoint.go
+++ b/api/router/endpoint.go
@@ -48,7 +48,7 @@ func (e *EndpointRouter) EndpointCreate(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	endpoint, err := e.endpoints.EndpointExecCreate(ctx, projectID, req.ExecID)
+	endpoint, err := e.endpoints.EndpointExecCreate(ctx, projectID, req.ExecID, req.Name)
 	if err != nil {
 		_ = render.Render(w, r, types.ErrHTTPError(err, "create endpoint failed"))
 

--- a/api/types/endpoint.go
+++ b/api/types/endpoint.go
@@ -6,6 +6,7 @@ import (
 )
 
 type EndpointCreate struct {
+	Name   string `json:"name"`
 	ExecID string `json:"execId"`
 }
 
@@ -25,6 +26,7 @@ type Endpoint struct {
 	ID           string         `json:"id"`
 	ProjectID    string         `json:"projectId"`
 	ExecID       string         `json:"execId"`
+	Name         string         `json:"name"`
 	HTTPEndpoint string         `json:"httpEndpoint"`
 	EvalIDs      []string       `json:"evalIDs"`
 	Status       EndpointStatus `json:"status"`

--- a/db/endpoint.sql.go
+++ b/db/endpoint.sql.go
@@ -125,21 +125,23 @@ func (q *Queries) EndpointCheckSteps(ctx context.Context, checkID string) ([]Unw
 }
 
 const EndpointCreate = `-- name: EndpointCreate :exec
-INSERT INTO unweave.endpoint (id, exec_id, project_id, http_address, created_at) VALUES ($1, $2, $3, $4, $5)
+INSERT INTO unweave.endpoint (id, exec_id, name, project_id, http_address, created_at) VALUES ($1, $2, $3, $4, $5, $6)
 `
 
 type EndpointCreateParams struct {
-	ID          string    `json:"id"`
-	ExecID      string    `json:"execID"`
-	ProjectID   string    `json:"projectID"`
-	HttpAddress string    `json:"httpAddress"`
-	CreatedAt   time.Time `json:"createdAt"`
+	ID          string         `json:"id"`
+	ExecID      string         `json:"execID"`
+	Name        sql.NullString `json:"name"`
+	ProjectID   string         `json:"projectID"`
+	HttpAddress string         `json:"httpAddress"`
+	CreatedAt   time.Time      `json:"createdAt"`
 }
 
 func (q *Queries) EndpointCreate(ctx context.Context, arg EndpointCreateParams) error {
 	_, err := q.db.ExecContext(ctx, EndpointCreate,
 		arg.ID,
 		arg.ExecID,
+		arg.Name,
 		arg.ProjectID,
 		arg.HttpAddress,
 		arg.CreatedAt,
@@ -198,7 +200,7 @@ func (q *Queries) EndpointEvalAttach(ctx context.Context, arg EndpointEvalAttach
 }
 
 const EndpointGet = `-- name: EndpointGet :one
-SELECT id, exec_id, project_id, http_address, created_at, deleted_at FROM unweave.endpoint WHERE id = $1
+SELECT id, exec_id, project_id, http_address, created_at, deleted_at, name FROM unweave.endpoint WHERE id = $1
 `
 
 func (q *Queries) EndpointGet(ctx context.Context, id string) (UnweaveEndpoint, error) {
@@ -211,12 +213,13 @@ func (q *Queries) EndpointGet(ctx context.Context, id string) (UnweaveEndpoint, 
 		&i.HttpAddress,
 		&i.CreatedAt,
 		&i.DeletedAt,
+		&i.Name,
 	)
 	return i, err
 }
 
 const EndpointsForProject = `-- name: EndpointsForProject :many
-SELECT id, exec_id, project_id, http_address, created_at, deleted_at FROM unweave.endpoint WHERE project_id = $1
+SELECT id, exec_id, project_id, http_address, created_at, deleted_at, name FROM unweave.endpoint WHERE project_id = $1
 `
 
 func (q *Queries) EndpointsForProject(ctx context.Context, projectID string) ([]UnweaveEndpoint, error) {
@@ -235,6 +238,7 @@ func (q *Queries) EndpointsForProject(ctx context.Context, projectID string) ([]
 			&i.HttpAddress,
 			&i.CreatedAt,
 			&i.DeletedAt,
+			&i.Name,
 		); err != nil {
 			return nil, err
 		}

--- a/db/migrations/20230713142344_endpoint_name.sql
+++ b/db/migrations/20230713142344_endpoint_name.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE unweave.endpoint ADD COLUMN name text UNIQUE;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE unweave.endpoint DROP COLUMN name;
+-- +goose StatementEnd

--- a/db/migrations/20230713142344_endpoint_name.sql
+++ b/db/migrations/20230713142344_endpoint_name.sql
@@ -1,9 +1,15 @@
 -- +goose Up
 -- +goose StatementBegin
-ALTER TABLE unweave.endpoint ADD COLUMN name text UNIQUE;
+ALTER TABLE unweave.endpoint ADD COLUMN name text;
+ALTER TABLE unweave.endpoint ADD CONSTRAINT unweave_endpoint_unique_name_by_project UNIQUE (project_id, name);
+ALTER TABLE unweave.endpoint ADD CONSTRAINT unweave_endpoint_unique_http_address UNIQUE (http_address);
+
 -- +goose StatementEnd
 
 -- +goose Down
 -- +goose StatementBegin
 ALTER TABLE unweave.endpoint DROP COLUMN name;
+ALTER TABLE unweave.endpoint DROP CONSTRAINT unweave_endpoint_unique_name_by_project;
+ALTER TABLE unweave.endpoint DROP CONSTRAINT unweave_endpoint_unique_http_address;
+
 -- +goose StatementEnd

--- a/db/models.go
+++ b/db/models.go
@@ -124,12 +124,13 @@ type UnweaveBuild struct {
 }
 
 type UnweaveEndpoint struct {
-	ID          string       `json:"id"`
-	ExecID      string       `json:"execID"`
-	ProjectID   string       `json:"projectID"`
-	HttpAddress string       `json:"httpAddress"`
-	CreatedAt   time.Time    `json:"createdAt"`
-	DeletedAt   sql.NullTime `json:"deletedAt"`
+	ID          string         `json:"id"`
+	ExecID      string         `json:"execID"`
+	ProjectID   string         `json:"projectID"`
+	HttpAddress string         `json:"httpAddress"`
+	CreatedAt   time.Time      `json:"createdAt"`
+	DeletedAt   sql.NullTime   `json:"deletedAt"`
+	Name        sql.NullString `json:"name"`
 }
 
 type UnweaveEndpointCheck struct {

--- a/db/queries/endpoint.sql
+++ b/db/queries/endpoint.sql
@@ -1,20 +1,20 @@
 -- name: EndpointCreate :exec
-INSERT INTO unweave.endpoint (id, exec_id, project_id, http_address, created_at) VALUES ($1, $2, $3, $4, $5);
+INSERT INTO unweave.endpoint (id, exec_id, name, project_id, http_address, created_at) VALUES ($1, $2, $3, $4, $5, $6);
 
 -- name: EndpointGet :one
-SELECT id, exec_id, project_id, http_address, created_at, deleted_at FROM unweave.endpoint WHERE id = $1;
+SELECT id, exec_id, project_id, http_address, created_at, deleted_at, name FROM unweave.endpoint WHERE id = $1;
 
 -- name: EndpointDelete :exec
 DELETE FROM unweave.endpoint WHERE id = $1;
+
+-- name: EndpointsForProject :many
+SELECT id, exec_id, project_id, http_address, created_at, deleted_at, name FROM unweave.endpoint WHERE project_id = $1;
 
 -- name: EndpointEval :many
 SELECT endpoint_id, eval_id FROM unweave.endpoint_eval WHERE endpoint_id = $1;
 
 -- name: EndpointEvalAttach :exec
 INSERT INTO unweave.endpoint_eval (endpoint_id, eval_id) VALUES ($1, $2);
-
--- name: EndpointsForProject :many
-SELECT id, exec_id, project_id, http_address, created_at, deleted_at FROM unweave.endpoint WHERE project_id = $1;
 
 -- name: EndpointCheckCreate :exec
 INSERT INTO unweave.endpoint_check (id, endpoint_id, project_id) VALUES ($1, $2, $3);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -134,7 +134,8 @@ CREATE TABLE unweave.endpoint (
     project_id text NOT NULL,
     http_address text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    deleted_at timestamp with time zone
+    deleted_at timestamp with time zone,
+    name text
 );
 
 ALTER TABLE unweave.endpoint OWNER TO postgres;
@@ -240,6 +241,9 @@ ALTER TABLE ONLY unweave.endpoint_check_step
 
 ALTER TABLE ONLY unweave.endpoint_eval
     ADD CONSTRAINT endpoint_eval_pkey PRIMARY KEY (endpoint_id, eval_id);
+
+ALTER TABLE ONLY unweave.endpoint
+    ADD CONSTRAINT endpoint_name_key UNIQUE (name);
 
 ALTER TABLE ONLY unweave.endpoint
     ADD CONSTRAINT endpoint_pkey PRIMARY KEY (id);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -243,9 +243,6 @@ ALTER TABLE ONLY unweave.endpoint_eval
     ADD CONSTRAINT endpoint_eval_pkey PRIMARY KEY (endpoint_id, eval_id);
 
 ALTER TABLE ONLY unweave.endpoint
-    ADD CONSTRAINT endpoint_name_key UNIQUE (name);
-
-ALTER TABLE ONLY unweave.endpoint
     ADD CONSTRAINT endpoint_pkey PRIMARY KEY (id);
 
 ALTER TABLE ONLY unweave.eval
@@ -277,6 +274,12 @@ ALTER TABLE ONLY unweave.ssh_key
 
 ALTER TABLE ONLY unweave.ssh_key
     ADD CONSTRAINT ssh_key_pkey PRIMARY KEY (id);
+
+ALTER TABLE ONLY unweave.endpoint
+    ADD CONSTRAINT unweave_endpoint_unique_http_address UNIQUE (http_address);
+
+ALTER TABLE ONLY unweave.endpoint
+    ADD CONSTRAINT unweave_endpoint_unique_name_by_project UNIQUE (project_id, name);
 
 ALTER TABLE ONLY unweave.volume
     ADD CONSTRAINT volume_pkey PRIMARY KEY (id);

--- a/providers/awsprov/driver_endpoint.go
+++ b/providers/awsprov/driver_endpoint.go
@@ -17,6 +17,6 @@ func (e *EndpointDriver) EndpointProvider() types.Provider {
 	return types.AWSProvider
 }
 
-func (e *EndpointDriver) EndpointCreate(_ context.Context, _, _, _ string, _ int32) (string, error) {
+func (e *EndpointDriver) EndpointCreate(_ context.Context, _, _, _, _ string, _ int32) (string, error) {
 	return "", errors.New("endpoints unsupported for aws provider")
 }

--- a/providers/lambdalabs/driver_endpoint.go
+++ b/providers/lambdalabs/driver_endpoint.go
@@ -17,6 +17,6 @@ func (e *EndpointDriver) EndpointProvider() types.Provider {
 	return types.LambdaLabsProvider
 }
 
-func (e *EndpointDriver) EndpointCreate(_ context.Context, _, _, _ string, _ int32) (string, error) {
+func (e *EndpointDriver) EndpointCreate(_ context.Context, _, _, _, _ string, _ int32) (string, error) {
 	return "", errors.New("endpoints unsupported for lambdalabs provider")
 }

--- a/services/evalsrv/service.go
+++ b/services/evalsrv/service.go
@@ -24,7 +24,7 @@ type Store interface {
 }
 
 type EndpointDriver interface {
-	EndpointCreate(ctx context.Context, project, endpointID, execID, name string, internalPort int32) (string, error)
+	EndpointCreate(ctx context.Context, project, endpointID, execID, subdomain string, internalPort int32) (string, error)
 }
 
 func NewEvalService(store Store, execService execsrv.Service, driver EndpointDriver) *EvalService {
@@ -68,7 +68,18 @@ func (e *EvalService) EvalCreate(ctx context.Context, projectID, execID string) 
 		}
 	}
 
-	addr, err := e.driver.EndpointCreate(ctx, projectID, evalID, execID, evalID, exec.Network.HTTPService.InternalPort)
+	// evals have an endpoiint subdomain
+	// equal to their evalID.
+	subdomain := evalID
+
+	addr, err := e.driver.EndpointCreate(
+		ctx,
+		projectID,
+		evalID,
+		execID,
+		subdomain,
+		exec.Network.HTTPService.InternalPort,
+	)
 	if err != nil {
 		return types.Eval{}, fmt.Errorf("failed to create endpoint for eval: %w", err)
 	}

--- a/services/evalsrv/service.go
+++ b/services/evalsrv/service.go
@@ -24,7 +24,7 @@ type Store interface {
 }
 
 type EndpointDriver interface {
-	EndpointCreate(ctx context.Context, project, endpointID, execID string, internalPort int32) (string, error)
+	EndpointCreate(ctx context.Context, project, endpointID, execID, name string, internalPort int32) (string, error)
 }
 
 func NewEvalService(store Store, execService execsrv.Service, driver EndpointDriver) *EvalService {
@@ -68,7 +68,7 @@ func (e *EvalService) EvalCreate(ctx context.Context, projectID, execID string) 
 		}
 	}
 
-	addr, err := e.driver.EndpointCreate(ctx, projectID, evalID, execID, exec.Network.HTTPService.InternalPort)
+	addr, err := e.driver.EndpointCreate(ctx, projectID, evalID, execID, evalID, exec.Network.HTTPService.InternalPort)
 	if err != nil {
 		return types.Eval{}, fmt.Errorf("failed to create endpoint for eval: %w", err)
 	}

--- a/tools/random/random.go
+++ b/tools/random/random.go
@@ -1,3 +1,4 @@
+//nolint:gosec
 package random
 
 import (
@@ -6,26 +7,54 @@ import (
 )
 
 const (
-	letterBytes   = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-	letterIdxBits = 6                    // 6 bits to represent a letter index
-	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
-	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+	letterBytes          = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	safeLowerLetterBytes = "0123456789bcdfghjklmnpqrstvwxyz" // vowels removed so we can't get swears
+	letterIdxBits        = 6                                 // 6 bits to represent a letter index
+	letterIdxMask        = 1<<letterIdxBits - 1              // All 1-bits, as many as letterIdxBits
+	letterIdxMax         = 63 / letterIdxBits                // # of letter indices fitting in 63 bits
 )
 
 func GenerateRandomString(n int) (string, error) {
-	b := make([]byte, n)
+	buffer := make([]byte, n)
 	// A src.Int63() generator is used to give us 63 random bits, enough to cover the letterIdxMax characters
-	for i, cache, remain := n-1, rand.Int63(), letterIdxMax; i >= 0; {
+	for letterIdx, cache, remain := n-1, rand.Int63(), letterIdxMax; letterIdx >= 0; {
 		if remain == 0 {
 			cache, remain = rand.Int63(), letterIdxMax
 		}
+
 		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
-			b[i] = letterBytes[idx]
-			i--
+			buffer[letterIdx] = letterBytes[idx]
+			letterIdx--
 		}
+
 		cache >>= letterIdxBits
 		remain--
 	}
 
-	return base64.RawURLEncoding.EncodeToString(b), nil
+	return base64.RawURLEncoding.EncodeToString(buffer), nil
+}
+
+// GenerateRandomLower creates a string of n length
+// that is entirely lowercase letters and numbers.
+// It's considered 'safe' because the alphabet has
+// vowels removed so that we cannot accidentally
+// generate swear words.
+func GenerateRandomLower(n int) string {
+	buffer := make([]byte, n)
+	// A src.Int63() generator is used to give us 63 random bits, enough to cover the letterIdxMax characters
+	for letterIdx, cache, remain := n-1, rand.Int63(), letterIdxMax; letterIdx >= 0; {
+		if remain == 0 {
+			cache, remain = rand.Int63(), letterIdxMax
+		}
+
+		if idx := int(cache & letterIdxMask); idx < len(safeLowerLetterBytes) {
+			buffer[letterIdx] = safeLowerLetterBytes[idx]
+			letterIdx--
+		}
+
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return string(buffer)
 }


### PR DESCRIPTION
Add a name to the endpoint, this name is used in the endpoint's URL. If the name is not provided in the create request, then a random 3 word phrase will be generated for the endpoint.