### PR TITLE
feat: Extensible eval checks

### DIFF
--- a/api/types/model.go
+++ b/api/types/model.go
@@ -238,3 +238,17 @@ var (
 func (c CheckConclusion) String() string {
 	return string(c)
 }
+
+type EvalManifest struct {
+	DatasetURL string `json:"datasetURL,omitempty"`
+	AssertURL  string `json:"assertURL,omitempty"`
+	RunURL     string `json:"runURL,omitempty"`
+}
+
+func DefaultEvalManifest() EvalManifest {
+	return EvalManifest{
+		DatasetURL: "/dataset",
+		AssertURL:  "/assert",
+		RunURL:     "",
+	}
+}

--- a/services/endpointsrv/checks.go
+++ b/services/endpointsrv/checks.go
@@ -1,0 +1,335 @@
+package endpointsrv
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/unweave/unweave/api/types"
+	"github.com/unweave/unweave/db"
+	"go.jetpack.io/typeid"
+)
+
+type endpointChecker struct {
+	checkID string
+	loaded  bool
+	checks  []checkEndpointStep
+}
+
+func newEndpointChecker(ctx context.Context, checkID string) (*endpointChecker, error) {
+	checker := &endpointChecker{
+		checkID: checkID,
+	}
+
+	return checker, nil
+}
+
+func (c *endpointChecker) Run(ctx context.Context) error {
+	if !c.loaded {
+		panic("check steps must be loaded before calling run")
+	}
+
+	go func() {
+		for _, check := range c.checks {
+			check.callEndpoint(ctx)
+			check.assertResponse(ctx)
+
+			if check.err != nil {
+				log.Error().Err(check.err).Msg("check failed")
+			}
+
+			log.Debug().
+				Str("check_id", check.checkID).
+				Str("step_id", check.stepID).
+				Str("input", string(check.input)).
+				Str("response", string(check.endpointResponse)).
+				Str("assertion", check.assertion).
+				Send()
+		}
+	}()
+
+	return nil
+}
+
+var ErrEndpointUnavailable = fmt.Errorf("endpoint unavailable")
+var ErrInvalidManifest = fmt.Errorf("manifest is invalid")
+var ErrInvalidDataset = fmt.Errorf("dataset is invalid")
+
+func fetchManifest(ctx context.Context, endpoint types.Endpoint, eval types.Eval) (types.EvalManifest, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+eval.HTTPEndpoint+"/", nil)
+	if err != nil {
+		return types.EvalManifest{}, fmt.Errorf("create request: %w", err)
+	}
+
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return types.EvalManifest{}, fmt.Errorf("fetch manifest: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode >= 500 {
+		return types.EvalManifest{}, fmt.Errorf("fetch manifest: %w", ErrEndpointUnavailable)
+	}
+
+	if response.StatusCode >= 400 {
+		return resolveManifestURLs(types.DefaultEvalManifest(), endpoint, eval)
+	}
+
+	if response.StatusCode != http.StatusOK {
+		return types.EvalManifest{}, fmt.Errorf(
+			"manifest endpoint status code must be 200, was %d: %w",
+			response.StatusCode,
+			ErrInvalidManifest,
+		)
+	}
+
+	var manifest types.EvalManifest
+	err = json.NewDecoder(response.Body).Decode(&manifest)
+	if err != nil {
+		return types.EvalManifest{}, fmt.Errorf("decoding manifest: %w", err)
+	}
+
+	return resolveManifestURLs(manifest, endpoint, eval)
+}
+
+// TODO: Security improvement needed to avoid calling loopback or internal endpoints
+func resolveManifestURLs(manifest types.EvalManifest, endpoint types.Endpoint, eval types.Eval) (types.EvalManifest, error) {
+	if manifest.RunURL == "" {
+		manifest.RunURL = "https://" + endpoint.HTTPAddress + "/"
+	}
+
+	var err error
+	manifest.RunURL, err = absoluteURL(manifest.RunURL, "https://"+eval.HTTPEndpoint)
+	if err != nil {
+		return types.EvalManifest{}, fmt.Errorf("absolute run url: %w", err)
+	}
+
+	manifest.DatasetURL, err = absoluteURL(manifest.DatasetURL, "https://"+eval.HTTPEndpoint+"/dataset")
+	if err != nil {
+		return types.EvalManifest{}, fmt.Errorf("absolute dataset url: %w", err)
+	}
+
+	manifest.AssertURL, err = absoluteURL(manifest.AssertURL, "https://"+eval.HTTPEndpoint+"/assert")
+	if err != nil {
+		return types.EvalManifest{}, fmt.Errorf("absolute assert url: %w", err)
+	}
+
+	return manifest, nil
+}
+
+func absoluteURL(ref string, base string) (string, error) {
+	if base == "" {
+		return "", fmt.Errorf("no base url provided")
+	}
+
+	baseURL, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse base url: %w", err)
+	}
+
+	if baseURL.Scheme == "" {
+		return "", fmt.Errorf("base url must have a scheme")
+	}
+
+	refURL, err := url.Parse(ref)
+	if err != nil {
+		return "", fmt.Errorf("parse ref url: %w", err)
+	}
+
+	result := baseURL.ResolveReference(refURL)
+
+	return result.String(), nil
+}
+
+func (c *endpointChecker) CreateCheckSteps(ctx context.Context, store Store, endpoint types.Endpoint, evals []types.Eval) error {
+	var checks []checkEndpointStep
+
+	for _, eval := range evals {
+		manifest, err := fetchManifest(ctx, endpoint, eval)
+		if err != nil {
+			return fmt.Errorf("fetch manifest: %w", err)
+		}
+
+		d, err := fetchDataset(ctx, manifest.DatasetURL)
+		if err != nil {
+			return fmt.Errorf("fetch dataset: %w", err)
+		}
+
+		for _, item := range d.Data {
+			stepID := typeid.Must(typeid.New("step")).String()
+
+			checks = append(checks, checkEndpointStep{
+				checkID:    c.checkID,
+				stepID:     stepID,
+				input:      item.Input,
+				runPath:    manifest.RunURL,
+				assertPath: manifest.AssertURL,
+				endpoint:   "https://" + endpoint.HTTPAddress + "/",
+				store:      store,
+			})
+
+			if err := store.EndpointCheckStepCreate(ctx, db.EndpointCheckStepCreateParams{
+				ID:      stepID,
+				CheckID: c.checkID,
+				EvalID:  eval.ID,
+				Input:   sql.NullString{String: string(item.Input), Valid: true},
+			}); err != nil {
+				return fmt.Errorf("create check step: %w", err)
+			}
+		}
+	}
+
+	c.checks = checks
+	c.loaded = true
+	return nil
+}
+
+type checkEndpointStep struct {
+	err error
+
+	checkID          string
+	stepID           string
+	runPath          string
+	assertPath       string
+	endpoint         string
+	input            json.RawMessage
+	endpointResponse json.RawMessage
+	assertion        string
+	store            Store
+}
+
+func (c *checkEndpointStep) callEndpoint(ctx context.Context) {
+	buf := bytes.NewBuffer(c.input)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.runPath, buf)
+	if err != nil {
+		c.err = fmt.Errorf("build endpoint request: %w", err)
+
+		return
+	}
+	req.Header.Set("X-Unweave-Target-Endpoint-URL", c.endpoint)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		c.err = fmt.Errorf("call endpoint: %w", err)
+
+		return
+	}
+
+	defer resp.Body.Close()
+
+	c.endpointResponse, c.err = io.ReadAll(resp.Body)
+
+	if err := c.store.EndpointCheckStepUpdate(ctx, db.EndpointCheckStepUpdateParams{
+		ID:     sql.NullString{String: c.stepID, Valid: true},
+		Output: sql.NullString{String: string(c.endpointResponse), Valid: true},
+	}); err != nil {
+		c.err = err
+	}
+}
+
+func (c *checkEndpointStep) assertResponse(ctx context.Context) {
+	buf := &bytes.Buffer{}
+
+	if err := json.
+		NewEncoder(buf).
+		Encode(datasetItemEndpointResponse{
+			EndpointResponse: c.endpointResponse,
+		}); err != nil {
+		c.err = fmt.Errorf("build assert body: %w", err)
+
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.assertPath, buf)
+	if err != nil {
+		c.err = fmt.Errorf("build assert request: %w", err)
+
+		return
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		c.err = fmt.Errorf("call assert: %w", err)
+
+		return
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		c.err = fmt.Errorf("assert status code: %d", resp.StatusCode)
+
+		return
+	}
+
+	var response struct {
+		Result string `json:"result"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		c.err = fmt.Errorf("decode assert response: %w", err)
+
+		return
+	}
+
+	c.assertion = response.Result
+	if err := c.store.EndpointCheckStepUpdate(ctx, db.EndpointCheckStepUpdateParams{
+		ID:        sql.NullString{String: c.stepID, Valid: true},
+		Assertion: sql.NullString{String: c.assertion, Valid: true},
+	}); err != nil {
+		c.err = err
+	}
+}
+
+type dataset struct {
+	Data []datasetItem `json:"data"`
+}
+
+type datasetItem struct {
+	Input json.RawMessage `json:"input"`
+}
+
+type datasetItemEndpointResponse struct {
+	EndpointResponse json.RawMessage `json:"endpointResponse"`
+}
+
+func fetchDataset(ctx context.Context, datasetPath string) (dataset, error) {
+	//nolint:gosec
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, datasetPath, nil)
+	if err != nil {
+		return dataset{}, fmt.Errorf("build dataset request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return dataset{}, fmt.Errorf("get dataset: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return dataset{}, fmt.Errorf("get dataset: status %d %w", resp.StatusCode, ErrEndpointUnavailable)
+	}
+
+	var data dataset
+
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return dataset{}, fmt.Errorf("decode dataset - %w: %w", ErrInvalidDataset, err)
+	}
+
+	return data, nil
+}

--- a/services/endpointsrv/checks_test.go
+++ b/services/endpointsrv/checks_test.go
@@ -1,0 +1,114 @@
+package endpointsrv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/unweave/unweave/api/types"
+)
+
+func TestAbsoluteURL(t *testing.T) {
+	type testCase struct {
+		name      string
+		baseURL   string
+		reference string
+		expected  string
+	}
+
+	testCases := []testCase{
+		{
+			name:      "absolute reference",
+			baseURL:   "https://example.com",
+			reference: "http://somewhere.com/ok",
+			expected:  "http://somewhere.com/ok",
+		},
+		{
+			name:      "relative reference",
+			baseURL:   "https://example.com/path",
+			reference: "/relative",
+			expected:  "https://example.com/relative",
+		},
+		{
+			name:      "empty reference",
+			baseURL:   "https://example.com/path",
+			reference: "",
+			expected:  "https://example.com/path",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			u, err := absoluteURL(test.reference, test.baseURL)
+
+			require.NoError(t, err)
+			require.Equal(t, test.expected, u)
+		})
+	}
+}
+
+func TestResolveManifestURLs(t *testing.T) {
+	type testCase struct {
+		name        string
+		input       types.EvalManifest
+		endpointURL string
+		evalURL     string
+		expected    types.EvalManifest
+	}
+
+	testCases := []testCase{
+		{
+			name:        "defaults",
+			input:       types.EvalManifest{},
+			endpointURL: "endpoint.example",
+			evalURL:     "eval.example",
+			expected: types.EvalManifest{
+				DatasetURL: "https://eval.example/dataset",
+				AssertURL:  "https://eval.example/assert",
+				RunURL:     "https://endpoint.example/",
+			},
+		},
+		{
+			name: "paths",
+			input: types.EvalManifest{
+				DatasetURL: "/updated-dataset",
+				AssertURL:  "/updated-assert",
+				RunURL:     "/run",
+			},
+			endpointURL: "endpoint.example",
+			evalURL:     "eval.example",
+			expected: types.EvalManifest{
+				DatasetURL: "https://eval.example/updated-dataset",
+				AssertURL:  "https://eval.example/updated-assert",
+				RunURL:     "https://eval.example/run",
+			},
+		},
+		{
+			name: "absolute urls",
+			input: types.EvalManifest{
+				DatasetURL: "http://somewhere/updated-dataset",
+				AssertURL:  "http://somewhere/updated-assert",
+				RunURL:     "http://somewhere/run",
+			},
+			endpointURL: "endpoint.example",
+			evalURL:     "eval.example",
+			expected: types.EvalManifest{
+				DatasetURL: "http://somewhere/updated-dataset",
+				AssertURL:  "http://somewhere/updated-assert",
+				RunURL:     "http://somewhere/run",
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			manifest, err := resolveManifestURLs(
+				test.input,
+				types.Endpoint{HTTPAddress: test.endpointURL},
+				types.Eval{HTTPEndpoint: test.evalURL},
+			)
+
+			require.NoError(t, err)
+			require.Equal(t, test.expected, manifest)
+		})
+	}
+}

--- a/services/endpointsrv/checks_test.go
+++ b/services/endpointsrv/checks_test.go
@@ -1,3 +1,4 @@
+//nolint:paralleltest,testpackage
 package endpointsrv
 
 import (

--- a/services/endpointsrv/service.go
+++ b/services/endpointsrv/service.go
@@ -1,4 +1,3 @@
-//nolint:noctx,godox
 package endpointsrv
 
 import (
@@ -282,7 +281,7 @@ func (e *EndpointService) RunEndpointEvals(ctx context.Context, projectID, endpo
 		return "", fmt.Errorf("create eval check: %w", err)
 	}
 
-	checker, err := newEndpointChecker(ctx, checkID)
+	checker, err := newEndpointChecker(checkID)
 	if err != nil {
 		return "", fmt.Errorf("new endpoint checker: %w", err)
 	}
@@ -292,6 +291,7 @@ func (e *EndpointService) RunEndpointEvals(ctx context.Context, projectID, endpo
 		return "", fmt.Errorf("create endpoint checks: %w", err)
 	}
 
+	//nolint:contextcheck
 	return checkID, checker.Run(context.Background())
 }
 
@@ -328,6 +328,7 @@ func (e *EndpointService) EndpointCheckStatus(ctx context.Context, checkID strin
 	}
 
 	out := make([]types.EndpointCheckStep, len(steps))
+
 	for idx, step := range steps {
 		status, conclusion := stepStatusAndConclusion(step)
 		out[idx] = types.EndpointCheckStep{
@@ -342,12 +343,14 @@ func (e *EndpointService) EndpointCheckStatus(ctx context.Context, checkID strin
 	}
 
 	status, conclusion := checkStatusAndConclusion(out)
-	return types.EndpointCheck{
+	check := types.EndpointCheck{
 		CheckID:    checkID,
 		Steps:      out,
 		Status:     status,
 		Conclusion: conclusion,
-	}, nil
+	}
+
+	return check, nil
 }
 
 func (e *EndpointService) EndpointVersionCreate(

--- a/services/endpointsrv/service.go
+++ b/services/endpointsrv/service.go
@@ -2,14 +2,9 @@
 package endpointsrv
 
 import (
-	"bytes"
 	"context"
-	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"net/http"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -287,33 +282,17 @@ func (e *EndpointService) RunEndpointEvals(ctx context.Context, projectID, endpo
 		return "", fmt.Errorf("create eval check: %w", err)
 	}
 
-	checks, err := buildEndpointCheckSteps(ctx, checkID, e.store, endpoint, evals)
+	checker, err := newEndpointChecker(ctx, checkID)
 	if err != nil {
-		return "", fmt.Errorf("build endpoint checks: %w", err)
+		return "", fmt.Errorf("new endpoint checker: %w", err)
 	}
 
-	go func() {
-		ctx := context.Background()
+	err = checker.CreateCheckSteps(ctx, e.store, endpoint, evals)
+	if err != nil {
+		return "", fmt.Errorf("create endpoint checks: %w", err)
+	}
 
-		for _, check := range checks {
-			check.callEndpoint(ctx)
-			check.assertResponse(ctx)
-
-			if check.err != nil {
-				log.Error().Err(check.err).Msg("check failed")
-			}
-
-			log.Debug().
-				Str("check_id", check.checkID).
-				Str("step_id", check.stepID).
-				Str("input", string(check.input)).
-				Str("response", string(check.endpointResponse)).
-				Str("assertion", check.assertion).
-				Send()
-		}
-	}()
-
-	return checkID, nil
+	return checkID, checker.Run(context.Background())
 }
 
 func verifyCanRunChecks(endpoint types.Endpoint, evals []types.Eval) error {
@@ -330,164 +309,6 @@ func verifyCanRunChecks(endpoint types.Endpoint, evals []types.Eval) error {
 	}
 
 	return nil
-}
-
-func buildEndpointCheckSteps(ctx context.Context, checkID string, store Store, endpoint types.Endpoint, evals []types.Eval) ([]checkEndpointStep, error) {
-	var checks []checkEndpointStep
-
-	for _, eval := range evals {
-		datasetPath := "https://" + eval.HTTPEndpoint + "/dataset"
-		assertPath := "https://" + eval.HTTPEndpoint + "/assert"
-
-		d, err := fetchDataset(datasetPath)
-		if err != nil {
-			return nil, fmt.Errorf("fetch dataset: %w", err)
-		}
-
-		for _, item := range d.Data {
-			stepID := typeid.Must(typeid.New("step")).String()
-
-			checks = append(checks, checkEndpointStep{
-				checkID:    checkID,
-				stepID:     stepID,
-				input:      item.Input,
-				assertPath: assertPath,
-				endpoint:   "https://" + endpoint.HTTPAddress,
-				store:      store,
-			})
-
-			if err := store.EndpointCheckStepCreate(ctx, db.EndpointCheckStepCreateParams{
-				ID:      stepID,
-				CheckID: checkID,
-				EvalID:  eval.ID,
-				Input:   sql.NullString{String: string(item.Input), Valid: true},
-			}); err != nil {
-				return nil, fmt.Errorf("create check step: %w", err)
-			}
-		}
-	}
-
-	return checks, nil
-}
-
-type checkEndpointStep struct {
-	err error
-
-	checkID          string
-	stepID           string
-	assertPath       string
-	endpoint         string
-	input            json.RawMessage
-	endpointResponse json.RawMessage
-	assertion        string
-	store            Store
-}
-
-func (c *checkEndpointStep) callEndpoint(ctx context.Context) {
-	buf := bytes.NewBuffer(c.input)
-
-	req, err := http.NewRequest(http.MethodPost, c.endpoint, buf)
-	if err != nil {
-		c.err = fmt.Errorf("build endpoint request: %w", err)
-
-		return
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		c.err = fmt.Errorf("call endpoint: %w", err)
-
-		return
-	}
-
-	defer resp.Body.Close()
-
-	c.endpointResponse, c.err = io.ReadAll(resp.Body)
-
-	if err := c.store.EndpointCheckStepUpdate(ctx, db.EndpointCheckStepUpdateParams{
-		ID:     sql.NullString{String: c.stepID, Valid: true},
-		Output: sql.NullString{String: string(c.endpointResponse), Valid: true},
-	}); err != nil {
-		c.err = err
-	}
-}
-
-func (c *checkEndpointStep) assertResponse(ctx context.Context) {
-	buf := &bytes.Buffer{}
-
-	if err := json.
-		NewEncoder(buf).
-		Encode(datasetItemEndpointResponse{
-			EndpointResponse: c.endpointResponse,
-		}); err != nil {
-		c.err = fmt.Errorf("build assert body: %w", err)
-
-		return
-	}
-
-	req, err := http.NewRequest(http.MethodPost, c.assertPath, buf)
-	if err != nil {
-		c.err = fmt.Errorf("build assert request: %w", err)
-
-		return
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		c.err = fmt.Errorf("call assert: %w", err)
-
-		return
-	}
-
-	defer resp.Body.Close()
-
-	var response struct {
-		Result string `json:"result"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		c.err = fmt.Errorf("decode assert response: %w", err)
-
-		return
-	}
-
-	c.assertion = response.Result
-	if err := c.store.EndpointCheckStepUpdate(ctx, db.EndpointCheckStepUpdateParams{
-		ID:        sql.NullString{String: c.stepID, Valid: true},
-		Assertion: sql.NullString{String: c.assertion, Valid: true},
-	}); err != nil {
-		c.err = err
-	}
-}
-
-type dataset struct {
-	Data []datasetItem `json:"data"`
-}
-
-type datasetItem struct {
-	Input json.RawMessage `json:"input"`
-}
-
-type datasetItemEndpointResponse struct {
-	EndpointResponse json.RawMessage `json:"endpointResponse"`
-}
-
-func fetchDataset(datasetPath string) (dataset, error) {
-	//nolint:gosec
-	resp, err := http.Get(datasetPath)
-	if err != nil {
-		return dataset{}, fmt.Errorf("get dataset: %w", err)
-	}
-
-	defer resp.Body.Close()
-
-	var data dataset
-
-	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return dataset{}, fmt.Errorf("decode dataset: %w", err)
-	}
-
-	return data, nil
 }
 
 func allHaveHTTPServiceHostname(evals ...types.Eval) bool {

--- a/tools/logged_http_transport.go
+++ b/tools/logged_http_transport.go
@@ -12,9 +12,10 @@ type transport struct {
 }
 
 func LoggedHTTPTransport(t http.RoundTripper) http.RoundTripper {
-	return &transport{base: http.DefaultTransport}
+	return &transport{base: t}
 }
 
+//nolint:wrapcheck
 func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	log.Debug().
 		Str("method", req.Method).
@@ -27,17 +28,17 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.base.RoundTrip(req)
 	duration := time.Since(startTime)
 
-	entry :=
-		log.Debug().
-			Str("method", req.Method).
-			Str("host", req.Host).
-			Str("path", req.URL.Path).
-			Str("event", "http_response").
-			Dur("duration", duration).
-			Err(err)
+	entry := log.Debug().
+		Str("method", req.Method).
+		Str("host", req.Host).
+		Str("path", req.URL.Path).
+		Str("event", "http_response").
+		Dur("duration", duration).
+		Err(err)
 	if err == nil {
 		entry.Int("status", resp.StatusCode)
 	}
+
 	entry.Send()
 
 	return resp, err

--- a/tools/logged_http_transport.go
+++ b/tools/logged_http_transport.go
@@ -1,0 +1,44 @@
+package tools
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+type transport struct {
+	base http.RoundTripper
+}
+
+func LoggedHTTPTransport(t http.RoundTripper) http.RoundTripper {
+	return &transport{base: http.DefaultTransport}
+}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	log.Debug().
+		Str("method", req.Method).
+		Str("host", req.Host).
+		Str("path", req.URL.Path).
+		Str("event", "http_request").
+		Send()
+
+	startTime := time.Now()
+	resp, err := t.base.RoundTrip(req)
+	duration := time.Since(startTime)
+
+	entry :=
+		log.Debug().
+			Str("method", req.Method).
+			Str("host", req.Host).
+			Str("path", req.URL.Path).
+			Str("event", "http_response").
+			Dur("duration", duration).
+			Err(err)
+	if err == nil {
+		entry.Int("status", resp.StatusCode)
+	}
+	entry.Send()
+
+	return resp, err
+}


### PR DESCRIPTION
Allow evals to serve an eval manifest in `/` where the user can pick to customise which endpoints to call for dataset, assert, and running the model.

By default running the model calls the endpoint directly. However, you can call another endpoint within the eval by returning a path in the eval manifest's runURL.

As an example, `"runURL": "/run"` would run the model against `<eval-url>/run` instead of `<endpoint-url>`.

The model run receives a header `X-Unweave-Target-Endpoint-URL` so the eval knows which endpoint we are targetting in the check.

This allows optional extensibility for users who need to do some data processing to call the model based from the dataset input.

You just need to add:

```python
@app.get("/")
async def manifest():
  return {"runURL": "/run"}

@app.post("/run")
ascync def run_check([...]):
  # call model URL from `X-Unweave-Target-Endpoint-URL`
```

This PR also includes a small code re-organisation, and better error handling of calls to `/dataset` and `/assert`.