### PR TITLE
refactor(builder): Smaller Builder interface

### DIFF
--- a/api/server/service.go
+++ b/api/server/service.go
@@ -10,25 +10,21 @@ import (
 )
 
 type Service struct {
-	rti     runtime.Initializer
-	aid     string // account ID
-	cid     string // caller ID
-	builder builder.Builder
-	vault   vault.Vault
+	rti   runtime.Initializer
+	aid   string // account ID
+	cid   string // caller ID
+	vault vault.Vault
 
 	Builder *BuilderService
 }
 
 func (s *Service) InitializeBuilder(ctx context.Context, builder string) (builder.Builder, error) {
-	if s.builder != nil {
-		return s.builder, nil
-	}
 	bld, err := s.rti.InitializeBuilder(ctx, s.cid, builder)
 	if err != nil {
 		return nil, err
 	}
-	s.builder = bld
-	return s.builder, nil
+
+	return bld, nil
 }
 
 func NewCtxService(rti runtime.Initializer, accountID, callerID string) *Service {
@@ -42,7 +38,6 @@ func NewCtxService(rti runtime.Initializer, accountID, callerID string) *Service
 		aid:     accountID,
 		cid:     callerID,
 		vault:   vlt,
-		builder: nil,
 		Builder: nil,
 	}
 	srv.Builder = &BuilderService{srv: srv}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -7,12 +7,6 @@ import (
 	"github.com/unweave/unweave/api/types"
 )
 
-// BuildLogsV1 versions the build logs format stored and fetched by the LogDriver.
-type BuildLogsV1 struct {
-	Version int16            `json:"version"`
-	Logs    []types.LogEntry `json:"logs"`
-}
-
 // LogDriver defines the interface for storing and retrieving build logs.
 type LogDriver interface {
 	// GetLogs returns the logs for a build.
@@ -23,25 +17,14 @@ type LogDriver interface {
 
 // Builder defines the interface for building and storing container images.
 type Builder interface {
-	// Build builds a container image from a build context.
-	// The build context is a zip file containing the source code and any other files
-	// needed to build the image. The buildCtx can be nil as long as it has been
-	// uploaded with the Upload method.
-	Build(ctx context.Context, buildID string, buildCtx io.Reader) error
-	// BuildAndPush builds a container image from a build context and pushes it to the
-	// container registry. This combines the functionality of the Build and Push methods.
+	// BuildAndPush builds a container image from a build context and pushes it
+	// to the cointainer registry.  The build context is a zip file containing
+	// the source code and any other files needed to build the image.
 	BuildAndPush(ctx context.Context, buildID, namespace, reponame string, buildCtx io.Reader) error
 	// GetBuilder returns the name of the builder.
 	GetBuilder() string
 	// GetImageURI returns the URI of the image in the container registry.
 	GetImageURI(ctx context.Context, buildID, namespace, reponame string) string
-	// HealthCheck returns an error if the builder is not healthy.
-	HealthCheck(ctx context.Context) error
 	// Logs returns the logs for a build.
 	Logs(ctx context.Context, buildID string) (logs []types.LogEntry, err error)
-	// Push pushes an image to the container registry. The buildID is used as the tag.
-	// If you want to use a different tag, use the Tag method instead.
-	Push(ctx context.Context, buildID, namespace, reponame string) error
-	// Upload uploads a build context to the builder. Must be a tar.gz file.
-	Upload(ctx context.Context, buildID string, buildCtx io.Reader) (err error)
 }

--- a/builder/fslogs/logger.go
+++ b/builder/fslogs/logger.go
@@ -1,4 +1,4 @@
-package builder
+package fslogs
 
 import (
 	"context"
@@ -11,9 +11,21 @@ import (
 	"github.com/unweave/unweave/api/types"
 )
 
+const buildLogsDir = "/tmp/unweave/logs"
+
+// BuildLogsV1 versions the build logs format stored and fetched by FsLogger.
+type BuildLogsV1 struct {
+	Version int16            `json:"version"`
+	Logs    []types.LogEntry `json:"logs"`
+}
+
 // FsLogger is a FileSystem logger that implements the builder.LogDriver interface.
 // It stores the build logs in a directory on the filesystem.
 type FsLogger struct{}
+
+func NewLogger() *FsLogger {
+	return &FsLogger{}
+}
 
 func (l *FsLogger) GetLogs(ctx context.Context, buildID string) ([]types.LogEntry, error) {
 	path := filepath.Join(buildLogsDir, buildID+".json")

--- a/initializer.go
+++ b/initializer.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 
 	"github.com/unweave/unweave/builder"
+	"github.com/unweave/unweave/builder/docker"
+	"github.com/unweave/unweave/builder/fslogs"
 	"github.com/unweave/unweave/tools/gonfig"
 	"github.com/unweave/unweave/vault"
 )
@@ -30,8 +32,10 @@ func (i *EnvInitializer) InitializeBuilder(ctx context.Context, userID string, b
 	if builderType != "docker" {
 		return nil, fmt.Errorf("%q builder not supported in the env initializer", builderType)
 	}
-	logger := &builder.FsLogger{}
-	return builder.NewBuilder(logger, cfg.RegistryURI), nil
+
+	logger := fslogs.NewLogger()
+
+	return docker.NewBuilder(logger, cfg.RegistryURI), nil
 }
 
 func (i *EnvInitializer) InitializeVault(ctx context.Context) (vault.Vault, error) {


### PR DESCRIPTION
Key changes:
* Removed unnecessary methods from the `builder.Builder`
* In the Builder Service, removed the redundant `Upload` step
* Extracted `DockerBuilder` and `FsLogger` into `builder/dokcker` and `builder/fslog`
* Stop caching builder into the service in case the builder is stateful and cannot be re-used across runs
* Fixed `(*DockerBuilder).Build` since `io.Reader` would panic if receiving a nil `buildContext`